### PR TITLE
docs: note PortAudio prerequisite for the pipecat extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ uv sync --all-extras            # or just one: --extra openai / --extra openai-a
 cp .env.example .env            # then fill in keys
 ```
 
+The **`pipecat` extra** pulls in `pyaudio`, which compiles against the system
+PortAudio library — install it first or the build fails with
+`fatal error: 'portaudio.h' file not found`:
+
+```bash
+brew install portaudio          # macOS
+sudo apt install portaudio19-dev  # Debian/Ubuntu
+```
+
+The other backends use `sounddevice` (PortAudio ships in its wheel), so this
+step is only needed for `--extra pipecat` / `--all-extras`.
+
 ### Required env
 
 - `LANGSMITH_API_KEY` — for tracing (optional, but the whole point of the demo)


### PR DESCRIPTION
## What

Documents that the `pipecat` extra requires the system **PortAudio** library, with the install command for macOS and Debian/Ubuntu.

## Why

`pipecat-ai[local]` depends on `pyaudio`, which builds a C extension against `portaudio.h`. On a machine without PortAudio installed, `uv sync --extra pipecat` (or `--all-extras`) fails the build with:

```
src/pyaudio/device_api.c:9:10: fatal error: 'portaudio.h' file not found
```

PortAudio is a system library, not a Python package, so `uv` can't install it. The note is scoped to the backends that actually need it — the other backends use `sounddevice`, which bundles PortAudio in its wheel.

## Change

Adds a short note to the Setup section:

```bash
brew install portaudio            # macOS
sudo apt install portaudio19-dev  # Debian/Ubuntu
```