### PR TITLE
Improve LangSmith trace quality for the SDK-traced OpenAI backends

### DIFF
--- a/src/voice_demo/openai/agent.py
+++ b/src/voice_demo/openai/agent.py
@@ -14,58 +14,13 @@ supplies the local-machine implementations, but the agent itself imports no
 console code — point it at a web/telephony transport and the same Realtime loop,
 tracing, and tool handling run unchanged.
 
-## Trace shape — one conversation = one trace
+## Tracing is separate
 
-Every *meaningful* received WebSocket event becomes its own span under the
-session root, in arrival order, carrying that event's full (scrubbed) payload —
-in `inputs` if the user sent it toward the model (speech buffer, transcription),
-in `outputs` if the model/server sent it back (`response.*`, `error`). The root
-span's `outputs` carries the running conversation transcript, so the LangSmith
-preview pane shows the whole exchange at a glance.
-
-Three classes of event are dropped to keep the trace readable: raw audio
-(`response.output_audio.delta`) is played but not spanned; every other streaming
-partial (`*.delta`) is dropped since the terminal `*.done` repeats the full
-payload; and purely structural bookkeeping events (`NOISE_EVENTS` — item/part
-add/done lifecycle markers that duplicate what `response.done` and the
-transcript events already carry) are dropped too. Work the agent does *while
-handling* an event (e.g. tool execution) nests inside that event's span, exactly
-as a tool call would in any other traced app.
-
-Spans are grouped into conversational `turn`s: a new turn opens each time the
-user starts speaking (`input_audio_buffer.speech_started`, which is also the
-barge-in signal), so one user utterance plus the agent's full response — tool
-calls and the spoken follow-up — sit under a single turn span. Pre-conversation
-`session.*` events arrive before any turn and stay under the root. This mirrors
-the `turn` grouping of the LiveKit and Pipecat backends.
-
-Readable events carry curated, conversation-shaped I/O (a user/assistant
-message) with the raw wire payload preserved under `metadata.raw_event`. Each
-`response.done` is a `chain` wrapper holding a point-in-time `model` (`llm`)
-span — assistant message (with token usage for cost rollup and finish status),
-`inputs` = the conversation context — alongside any tool runs it triggered, so
-local tool latency is never attributed to the model call. The agent transcript
-(`response.output_audio_transcript.done`) and the tool args
-(`response.function_call_arguments.done`) are *not* spanned separately — the
-`model` span already carries both — but the transcript still builds the root
-conversation + prints to the console. The root is titled with the first user
-utterance; each turn records `latency_to_first_audio_ms` and, on a barge-in,
-`was_interrupted`.
-
-    realtime_session                                   (root; metadata.title = first utterance)
-    │  outputs: { messages: [...] }                   (full conversation transcript)
-    │  attachments: conversation.wav                  (stereo: L=user, R=agent)
-    │
-    ├── session.created / session.updated             (pre-conversation setup)
-    ├── turn                                           (metadata: latency_ms, was_interrupted)
-    │   ├── input_audio_buffer.speech_started         (event)
-    │   ├── input_audio_buffer.speech_stopped         (event)
-    │   ├── conversation.item.input_audio_transcription.completed   (user message)
-    │   ├── response.done                             (chain wrapper)
-    │   │   ├── model                                 (llm — inputs=context, msg + tokens + status)
-    │   │   └── lookup_weather × N                    (tool — sibling of the model span)
-    │   └── response.done                             (chain → model llm, spoken follow-up)
-    └── turn                                           (next user utterance …)
+This module is the *application*: the conversation loop, audio playback, UI
+state, and the tool call cycle. All LangSmith tracing lives in `tracing.py`
+(`RealtimeTracer`). The loop wraps each event in `tracer.track_event(event)` and
+its body holds only application side-effects — no span, turn, transcript, or
+metric code. See `tracing.py` for the resulting trace shape.
 """
 
 from __future__ import annotations
@@ -76,20 +31,14 @@ import json
 import os
 import sys
 import uuid
-from typing import Any
 
-from langsmith.run_helpers import tracing_context
 from openai import AsyncOpenAI
 
 from ..audio import AudioInput, AudioOutput
 from ..console import NullUI, StatusUI, frame_level
 from ..sdk_tracing import start_session
-from .utils import (
-    execute_tool,
-    is_inbound,
-    response_assistant_output,
-    response_usage_metadata,
-)
+from .tracing import RealtimeTracer
+from .utils import execute_tool
 
 
 SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
@@ -119,26 +68,6 @@ WEATHER_TOOL = {
 
 DEFAULT_MODEL = os.getenv("REALTIME_MODEL", "gpt-realtime-2")
 SAMPLE_RATE = 24_000
-
-# Structural bookkeeping events the server sends to track item/content-part
-# lifecycle. They carry no behavioral handler and only duplicate state already
-# captured by `response.done` and the transcript events, so spanning them just
-# floods the trace. Dropped before a span is opened (cf. the `*.delta` skip).
-NOISE_EVENTS = frozenset(
-    {
-        "input_audio_buffer.committed",
-        "conversation.item.added",
-        "conversation.item.done",
-        "response.created",
-        "response.output_item.added",
-        "response.output_item.done",
-        "response.content_part.added",
-        "response.content_part.done",
-        "response.output_audio.done",
-        # Redundant with the `model` llm span's tool_calls + the tool span's args.
-        "response.function_call_arguments.done",
-    }
-)
 
 
 async def run(
@@ -174,13 +103,11 @@ async def run(
         tags=["voice-demo", "openai", "session"],
         metadata={"thread_id": thread_id, "model": DEFAULT_MODEL},
     )
+    # All tracing of the event stream lives in the tracer (see tracing.py).
+    tracer = RealtimeTracer(session, audio_out)
     mic_task: asyncio.Task | None = None
 
-    with tracing_context(
-        metadata={"thread_id": thread_id},
-        tags=["voice-demo", "openai"],
-        project_name=project_name,
-    ):
+    with tracer.trace_context(tags=["voice-demo", "openai"]):
         try:
             async with client.realtime.connect(model=DEFAULT_MODEL) as connection:
                 await connection.session.update(
@@ -234,144 +161,60 @@ async def run(
 
                 mic_task = asyncio.create_task(pump_mic())
 
-                # Per-turn latency: end-of-user-speech → first agent audio
-                # (perceived response lag). Set at speech_stopped, recorded on
-                # the first audio chunk (then cleared), reset per user turn.
-                # `None` = not armed.
-                await_audio_since: float | None = None
-
+                # Application event loop. Every event is wrapped in
+                # `tracer.track_event(...)`, which owns all tracing; the body
+                # below is pure application behavior — play audio, set UI state,
+                # run tools, ask the model to respond. Tool calls auto-nest under
+                # the event's span because the tracer sets the parent context.
                 async for event in connection:
-                    event_type = event.type
-                    received_at = session.now()
+                    with tracer.track_event(event):
+                        event_type = event.type
 
-                    # Raw audio: hundreds of chunks per response. Play it, but
-                    # don't span it.
-                    if event_type == "response.output_audio.delta":
-                        if await_audio_since is not None:
-                            session.add_turn_metadata(
-                                latency_to_first_audio_ms=round(
-                                    (received_at - await_audio_since) * 1000
-                                )
-                            )
-                            await_audio_since = None
-                        chunk = base64.b64decode(event.delta)
-                        audio_out.write(chunk)
-                        ui.set_state("speaking")
-                        # NB: not recorded here — the speaker's played-callback
-                        # records what's actually played (see set_played_callback
-                        # above), so barge-in truncation is captured correctly.
-                        continue
+                        if event_type == "response.output_audio.delta":
+                            # Hundreds of chunks per response — play each as it
+                            # arrives. (The played-callback records what's heard.)
+                            audio_out.write(base64.b64decode(event.delta))
+                            ui.set_state("speaking")
 
-                    # Skip every other streaming partial (`*.delta`) — they're
-                    # too noisy and the terminal `*.done` event carries the
-                    # complete payload.
-                    if event_type.endswith(".delta"):
-                        continue
-
-                    # Skip purely structural lifecycle events (see NOISE_EVENTS):
-                    # they have no behavioral handler and only duplicate state
-                    # `response.done` / the transcript events already carry.
-                    if event_type in NOISE_EVENTS:
-                        continue
-
-                    # A user starting to speak begins a new conversational turn
-                    # (this is also the barge-in signal). Open the turn span
-                    # before this event's span so speech_started and everything
-                    # up to the next speech_started nest under it. Pre-conversation
-                    # session.* events precede any turn and stay under the root.
-                    if event_type == "input_audio_buffer.speech_started":
-                        # Barge-in: the user spoke while the agent still had
-                        # audio queued. Flag the turn being interrupted before
-                        # start_turn() closes it.
-                        if audio_out.buffered_bytes() > 0:
-                            session.add_turn_metadata(was_interrupted=True)
-                        session.start_turn()
-
-                    # The agent transcript is already the `model` llm span's
-                    # content (recorded at response.done); don't span it twice.
-                    # Use it to build the root transcript + print to the console,
-                    # then drop the redundant event span.
-                    if event_type == "response.output_audio_transcript.done":
-                        transcript = (event.transcript or "").strip()
-                        if transcript:
-                            ui.log(f"agent: {transcript}")
-                            session.add_message("assistant", transcript)
-                        continue
-
-                    # Curated, conversation-shaped I/O for the readable events;
-                    # everything else keeps its raw wire payload (see event_span).
-                    span_kwargs: dict[str, Any] = {"inbound": is_inbound(event_type)}
-                    if event_type == "conversation.item.input_audio_transcription.completed":
-                        user_text = (event.transcript or "").strip()
-                        if user_text:
-                            span_kwargs["inputs"] = {"role": "user", "content": user_text}
-                    elif event_type == "response.done":
-                        # Keep this event span a `chain` wrapper; the model payload
-                        # (assistant message, tokens, status) goes on a child `llm`
-                        # span recorded in the handler below, so local tool latency
-                        # in this handler is never attributed to the model call.
-                        # Empty outputs → the raw response is preserved under
-                        # metadata.raw_event; the child `llm` span is the readable one.
-                        span_kwargs["outputs"] = {}
-
-                    # Every other event becomes its own span, carrying the
-                    # event's payload. Work done while handling it (e.g. tool
-                    # execution) nests inside via tracing_context(parent=event_run).
-                    with session.event_span(
-                        event, received_at, name=event_type, **span_kwargs
-                    ) as event_run:
-                        if event_type == "input_audio_buffer.speech_started":
-                            # A new turn supersedes any latency measurement still
-                            # pending from the previous turn (e.g. the user spoke
-                            # again before the last response produced audio) —
-                            # discard it so it can't be attributed to this turn.
-                            await_audio_since = None
+                        elif event_type == "input_audio_buffer.speech_started":
                             # Barge-in: flush whatever the agent was still saying.
                             audio_out.clear()
                             ui.set_state("hearing you")
 
                         elif event_type == "input_audio_buffer.speech_stopped":
-                            # Arm the latency timer: from here to the first agent
-                            # audio chunk is the perceived response lag.
-                            await_audio_since = received_at
                             ui.set_state("transcribing")
 
-                        elif event_type == "conversation.item.input_audio_transcription.completed":
+                        elif (
+                            event_type
+                            == "conversation.item.input_audio_transcription.completed"
+                        ):
                             transcript = (event.transcript or "").strip()
                             if not transcript:
-                                # Noise — nothing usable was transcribed.
                                 ui.log("[openai] (no speech detected)")
-                                await_audio_since = None
                                 ui.set_state("listening")
                             else:
                                 ui.log(f"user:  {transcript}")
-                                session.add_message("user", transcript)
-                                session.set_title(transcript)  # first utterance → trace title
-                                # Turn detection is configured with
-                                # create_response=False, so we explicitly ask the
-                                # model to respond once the turn is transcribed.
+                                # Turn detection uses create_response=False, so we
+                                # explicitly ask the model to respond once the turn
+                                # is transcribed.
                                 ui.set_state("thinking")
                                 await connection.response.create()
 
-                        elif event_type == "conversation.item.input_audio_transcription.failed":
-                            # The model couldn't transcribe the turn — surface it
-                            # (errored span + log) so "it didn't understand me" is
-                            # debuggable, and don't leave the latency timer armed.
-                            reason = getattr(event, "error", None)
-                            ui.log(f"[openai] transcription failed: {reason}")
-                            event_run.error = f"transcription_failed: {reason}"
-                            await_audio_since = None
+                        elif (
+                            event_type
+                            == "conversation.item.input_audio_transcription.failed"
+                        ):
+                            ui.log(
+                                f"[openai] transcription failed: {getattr(event, 'error', None)}"
+                            )
                             ui.set_state("listening")
 
+                        elif event_type == "response.output_audio_transcript.done":
+                            transcript = (event.transcript or "").strip()
+                            if transcript:
+                                ui.log(f"agent: {transcript}")
+
                         elif event_type == "response.done":
-                            # Point-in-time `llm` span for the model payload:
-                            # assistant message, token usage (cost), finish status.
-                            session.record_llm(
-                                event_run,
-                                outputs=response_assistant_output(event.response),
-                                usage_metadata=response_usage_metadata(event.response),
-                                metadata={"status": getattr(event.response, "status", None)},
-                            )
                             # The done event carries the complete response,
                             # including any function calls — no need to collect
                             # them from earlier streaming events.
@@ -381,14 +224,14 @@ async def run(
                                 if item.type == "function_call"
                             ]
                             if tool_calls:
-                                # Run them nested under THIS event, then ask for
-                                # the spoken follow-up. (response.create() must
-                                # wait for response.done — the API allows one
-                                # active response at a time.)
+                                # Run them, then ask for the spoken follow-up.
+                                # (response.create() must wait for response.done —
+                                # the API allows one active response at a time.)
                                 ui.set_state("running tools")
                                 for call in tool_calls:
-                                    with tracing_context(parent=event_run):
-                                        result = await execute_tool(call.name, call.arguments)
+                                    result = await execute_tool(
+                                        call.name, call.arguments
+                                    )
                                     await connection.conversation.item.create(
                                         item={
                                             "type": "function_call_output",

--- a/src/voice_demo/openai/agent.py
+++ b/src/voice_demo/openai/agent.py
@@ -16,29 +16,56 @@ tracing, and tool handling run unchanged.
 
 ## Trace shape — one conversation = one trace
 
-Every received WebSocket event becomes its own span under the session root, in
-arrival order, carrying that event's full (scrubbed) payload — in `inputs` if
-the user sent it toward the model (speech buffer, transcription), in `outputs`
-if the model/server sent it back (`response.*`, `error`). Raw audio
-(`response.output_audio.delta`) is played but not spanned, and every other
-streaming partial (`*.delta`) is dropped too — the terminal `*.done` events
-carry the complete payload. Work the agent does *while handling* an event (e.g.
-tool execution) nests inside that event's span, exactly as a tool call would in
-any other traced app.
+Every *meaningful* received WebSocket event becomes its own span under the
+session root, in arrival order, carrying that event's full (scrubbed) payload —
+in `inputs` if the user sent it toward the model (speech buffer, transcription),
+in `outputs` if the model/server sent it back (`response.*`, `error`). The root
+span's `outputs` carries the running conversation transcript, so the LangSmith
+preview pane shows the whole exchange at a glance.
 
-    realtime_session                                   (root)
+Three classes of event are dropped to keep the trace readable: raw audio
+(`response.output_audio.delta`) is played but not spanned; every other streaming
+partial (`*.delta`) is dropped since the terminal `*.done` repeats the full
+payload; and purely structural bookkeeping events (`NOISE_EVENTS` — item/part
+add/done lifecycle markers that duplicate what `response.done` and the
+transcript events already carry) are dropped too. Work the agent does *while
+handling* an event (e.g. tool execution) nests inside that event's span, exactly
+as a tool call would in any other traced app.
+
+Spans are grouped into conversational `turn`s: a new turn opens each time the
+user starts speaking (`input_audio_buffer.speech_started`, which is also the
+barge-in signal), so one user utterance plus the agent's full response — tool
+calls and the spoken follow-up — sit under a single turn span. Pre-conversation
+`session.*` events arrive before any turn and stay under the root. This mirrors
+the `turn` grouping of the LiveKit and Pipecat backends.
+
+Readable events carry curated, conversation-shaped I/O (a user/assistant
+message) with the raw wire payload preserved under `metadata.raw_event`. Each
+`response.done` is a `chain` wrapper holding a point-in-time `model` (`llm`)
+span — assistant message (with token usage for cost rollup and finish status),
+`inputs` = the conversation context — alongside any tool runs it triggered, so
+local tool latency is never attributed to the model call. The agent transcript
+(`response.output_audio_transcript.done`) and the tool args
+(`response.function_call_arguments.done`) are *not* spanned separately — the
+`model` span already carries both — but the transcript still builds the root
+conversation + prints to the console. The root is titled with the first user
+utterance; each turn records `latency_to_first_audio_ms` and, on a barge-in,
+`was_interrupted`.
+
+    realtime_session                                   (root; metadata.title = first utterance)
+    │  outputs: { messages: [...] }                   (full conversation transcript)
     │  attachments: conversation.wav                  (stereo: L=user, R=agent)
-    │  metadata: event_count, duration_s
     │
-    ├── input_audio_buffer.speech_started             (event)
-    ├── input_audio_buffer.speech_stopped             (event)
-    ├── conversation.item.input_audio_transcription.completed   (event)
-    ├── response.created                              (event)
-    ├── response.function_call_arguments.done         (event)
-    ├── response.done                                 (event)
-    │   └── lookup_weather × N                        (ran while handling this event)
-    ├── response.done                                 (event — post-tool follow-up)
-    └── error                                         (event, if the server sent one)
+    ├── session.created / session.updated             (pre-conversation setup)
+    ├── turn                                           (metadata: latency_ms, was_interrupted)
+    │   ├── input_audio_buffer.speech_started         (event)
+    │   ├── input_audio_buffer.speech_stopped         (event)
+    │   ├── conversation.item.input_audio_transcription.completed   (user message)
+    │   ├── response.done                             (chain wrapper)
+    │   │   ├── model                                 (llm — inputs=context, msg + tokens + status)
+    │   │   └── lookup_weather × N                    (tool — sibling of the model span)
+    │   └── response.done                             (chain → model llm, spoken follow-up)
+    └── turn                                           (next user utterance …)
 """
 
 from __future__ import annotations
@@ -49,6 +76,7 @@ import json
 import os
 import sys
 import uuid
+from typing import Any
 
 from langsmith.run_helpers import tracing_context
 from openai import AsyncOpenAI
@@ -56,7 +84,12 @@ from openai import AsyncOpenAI
 from ..audio import AudioInput, AudioOutput
 from ..console import NullUI, StatusUI, frame_level
 from ..sdk_tracing import start_session
-from .utils import execute_tool, is_inbound
+from .utils import (
+    execute_tool,
+    is_inbound,
+    response_assistant_output,
+    response_usage_metadata,
+)
 
 
 SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
@@ -86,6 +119,26 @@ WEATHER_TOOL = {
 
 DEFAULT_MODEL = os.getenv("REALTIME_MODEL", "gpt-realtime-2")
 SAMPLE_RATE = 24_000
+
+# Structural bookkeeping events the server sends to track item/content-part
+# lifecycle. They carry no behavioral handler and only duplicate state already
+# captured by `response.done` and the transcript events, so spanning them just
+# floods the trace. Dropped before a span is opened (cf. the `*.delta` skip).
+NOISE_EVENTS = frozenset(
+    {
+        "input_audio_buffer.committed",
+        "conversation.item.added",
+        "conversation.item.done",
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_audio.done",
+        # Redundant with the `model` llm span's tool_calls + the tool span's args.
+        "response.function_call_arguments.done",
+    }
+)
 
 
 async def run(
@@ -181,6 +234,12 @@ async def run(
 
                 mic_task = asyncio.create_task(pump_mic())
 
+                # Per-turn latency: end-of-user-speech → first agent audio
+                # (perceived response lag). Set at speech_stopped, recorded on
+                # the first audio chunk (then cleared), reset per user turn.
+                # `None` = not armed.
+                await_audio_since: float | None = None
+
                 async for event in connection:
                     event_type = event.type
                     received_at = session.now()
@@ -188,6 +247,13 @@ async def run(
                     # Raw audio: hundreds of chunks per response. Play it, but
                     # don't span it.
                     if event_type == "response.output_audio.delta":
+                        if await_audio_since is not None:
+                            session.add_turn_metadata(
+                                latency_to_first_audio_ms=round(
+                                    (received_at - await_audio_since) * 1000
+                                )
+                            )
+                            await_audio_since = None
                         chunk = base64.b64decode(event.delta)
                         audio_out.write(chunk)
                         ui.set_state("speaking")
@@ -202,18 +268,72 @@ async def run(
                     if event_type.endswith(".delta"):
                         continue
 
+                    # Skip purely structural lifecycle events (see NOISE_EVENTS):
+                    # they have no behavioral handler and only duplicate state
+                    # `response.done` / the transcript events already carry.
+                    if event_type in NOISE_EVENTS:
+                        continue
+
+                    # A user starting to speak begins a new conversational turn
+                    # (this is also the barge-in signal). Open the turn span
+                    # before this event's span so speech_started and everything
+                    # up to the next speech_started nest under it. Pre-conversation
+                    # session.* events precede any turn and stay under the root.
+                    if event_type == "input_audio_buffer.speech_started":
+                        # Barge-in: the user spoke while the agent still had
+                        # audio queued. Flag the turn being interrupted before
+                        # start_turn() closes it.
+                        if audio_out.buffered_bytes() > 0:
+                            session.add_turn_metadata(was_interrupted=True)
+                        session.start_turn()
+
+                    # The agent transcript is already the `model` llm span's
+                    # content (recorded at response.done); don't span it twice.
+                    # Use it to build the root transcript + print to the console,
+                    # then drop the redundant event span.
+                    if event_type == "response.output_audio_transcript.done":
+                        transcript = (event.transcript or "").strip()
+                        if transcript:
+                            ui.log(f"agent: {transcript}")
+                            session.add_message("assistant", transcript)
+                        continue
+
+                    # Curated, conversation-shaped I/O for the readable events;
+                    # everything else keeps its raw wire payload (see event_span).
+                    span_kwargs: dict[str, Any] = {"inbound": is_inbound(event_type)}
+                    if event_type == "conversation.item.input_audio_transcription.completed":
+                        user_text = (event.transcript or "").strip()
+                        if user_text:
+                            span_kwargs["inputs"] = {"role": "user", "content": user_text}
+                    elif event_type == "response.done":
+                        # Keep this event span a `chain` wrapper; the model payload
+                        # (assistant message, tokens, status) goes on a child `llm`
+                        # span recorded in the handler below, so local tool latency
+                        # in this handler is never attributed to the model call.
+                        # Empty outputs → the raw response is preserved under
+                        # metadata.raw_event; the child `llm` span is the readable one.
+                        span_kwargs["outputs"] = {}
+
                     # Every other event becomes its own span, carrying the
                     # event's payload. Work done while handling it (e.g. tool
                     # execution) nests inside via tracing_context(parent=event_run).
                     with session.event_span(
-                        event, received_at, name=event_type, inbound=is_inbound(event_type)
+                        event, received_at, name=event_type, **span_kwargs
                     ) as event_run:
                         if event_type == "input_audio_buffer.speech_started":
+                            # A new turn supersedes any latency measurement still
+                            # pending from the previous turn (e.g. the user spoke
+                            # again before the last response produced audio) —
+                            # discard it so it can't be attributed to this turn.
+                            await_audio_since = None
                             # Barge-in: flush whatever the agent was still saying.
                             audio_out.clear()
                             ui.set_state("hearing you")
 
                         elif event_type == "input_audio_buffer.speech_stopped":
+                            # Arm the latency timer: from here to the first agent
+                            # audio chunk is the perceived response lag.
+                            await_audio_since = received_at
                             ui.set_state("transcribing")
 
                         elif event_type == "conversation.item.input_audio_transcription.completed":
@@ -221,19 +341,37 @@ async def run(
                             if not transcript:
                                 # Noise — nothing usable was transcribed.
                                 ui.log("[openai] (no speech detected)")
+                                await_audio_since = None
                                 ui.set_state("listening")
                             else:
                                 ui.log(f"user:  {transcript}")
+                                session.add_message("user", transcript)
+                                session.set_title(transcript)  # first utterance → trace title
                                 # Turn detection is configured with
                                 # create_response=False, so we explicitly ask the
                                 # model to respond once the turn is transcribed.
                                 ui.set_state("thinking")
                                 await connection.response.create()
 
-                        elif event_type == "response.output_audio_transcript.done":
-                            ui.log(f"agent: {event.transcript or ''}")
+                        elif event_type == "conversation.item.input_audio_transcription.failed":
+                            # The model couldn't transcribe the turn — surface it
+                            # (errored span + log) so "it didn't understand me" is
+                            # debuggable, and don't leave the latency timer armed.
+                            reason = getattr(event, "error", None)
+                            ui.log(f"[openai] transcription failed: {reason}")
+                            event_run.error = f"transcription_failed: {reason}"
+                            await_audio_since = None
+                            ui.set_state("listening")
 
                         elif event_type == "response.done":
+                            # Point-in-time `llm` span for the model payload:
+                            # assistant message, token usage (cost), finish status.
+                            session.record_llm(
+                                event_run,
+                                outputs=response_assistant_output(event.response),
+                                usage_metadata=response_usage_metadata(event.response),
+                                metadata={"status": getattr(event.response, "status", None)},
+                            )
                             # The done event carries the complete response,
                             # including any function calls — no need to collect
                             # them from earlier streaming events.

--- a/src/voice_demo/openai/tracing.py
+++ b/src/voice_demo/openai/tracing.py
@@ -1,0 +1,330 @@
+"""LangSmith tracing for the raw OpenAI Realtime backend.
+
+This module owns *everything* that turns the Realtime WebSocket event stream
+into a LangSmith trace. It is deliberately kept apart from the application logic
+in `agent.py`: the agent's event loop wraps each event in
+`RealtimeTracer.track_event(...)` and its body contains only application
+side-effects (play audio, set UI state, run tools, ask the model to respond).
+Every trace decision lives here — which events become spans, how they group into
+turns, the conversation transcript rollup, the per-turn latency/interruption
+metrics, and the point-in-time `llm` spans.
+
+The tracer wraps the shared `voice_demo.sdk_tracing.EventSession` (root span,
+turns, WAV attachment, payload scrubbing); this module is the OpenAI-Realtime
+*policy* layered on that mechanism.
+
+## Trace shape — one conversation = one trace
+
+Every *meaningful* received WebSocket event becomes its own span, in arrival
+order, carrying that event's full (scrubbed) payload — in `inputs` if the user
+sent it toward the model (speech buffer, transcription), in `outputs` if the
+model/server sent it back (`response.*`, `error`). The root span's `outputs`
+carries the running conversation transcript, so the LangSmith preview pane shows
+the whole exchange at a glance.
+
+Three classes of event are dropped to keep the trace readable: raw audio
+(`response.output_audio.delta`) is played but not spanned; every other streaming
+partial (`*.delta`) is dropped since the terminal `*.done` repeats the full
+payload; and purely structural bookkeeping events (`NOISE_EVENTS` — item/part
+add/done lifecycle markers that duplicate what `response.done` and the
+transcript events already carry) are dropped too. Work the agent does *while
+handling* an event (e.g. tool execution) nests inside that event's span: the
+tracer sets `tracing_context(parent=...)` for the duration of the `with` body,
+so the app's tool calls auto-nest without ever touching the run object.
+
+Spans are grouped into conversational `turn`s: a new turn opens each time the
+user starts speaking (`input_audio_buffer.speech_started`, which is also the
+barge-in signal), so one user utterance plus the agent's full response — tool
+calls and the spoken follow-up — sit under a single turn span. Pre-conversation
+`session.*` events arrive before any turn and stay under the root. This mirrors
+the `turn` grouping of the LiveKit and Pipecat backends.
+
+Readable events carry curated, conversation-shaped I/O (a user/assistant
+message) with the raw wire payload preserved under `metadata.raw_event`. Each
+`response.done` is a `chain` wrapper holding a point-in-time `model` (`llm`)
+span — assistant message (with token usage for cost rollup and finish status),
+`inputs` = the conversation context — alongside any tool runs it triggered, so
+local tool latency is never attributed to the model call. The agent transcript
+(`response.output_audio_transcript.done`) and the tool args
+(`response.function_call_arguments.done`) are *not* spanned separately — the
+`model` span already carries both — but the transcript still builds the root
+conversation. The root is titled with the first user utterance; each turn
+records `latency_to_first_audio_ms` and, on a barge-in, `was_interrupted`.
+
+    realtime_session                                   (root; metadata.title = first utterance)
+    │  outputs: { messages: [...] }                   (full conversation transcript)
+    │  attachments: conversation.wav                  (stereo: L=user, R=agent)
+    │
+    ├── session.created / session.updated             (pre-conversation setup)
+    ├── turn                                           (metadata: latency_ms, was_interrupted)
+    │   ├── input_audio_buffer.speech_started         (event)
+    │   ├── input_audio_buffer.speech_stopped         (event)
+    │   ├── conversation.item.input_audio_transcription.completed   (user message)
+    │   ├── response.done                             (chain wrapper)
+    │   │   ├── model                                 (llm — inputs=context, msg + tokens + status)
+    │   │   └── lookup_weather × N                    (tool — sibling of the model span)
+    │   └── response.done                             (chain → model llm, spoken follow-up)
+    └── turn                                           (next user utterance …)
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+from langsmith.run_helpers import tracing_context
+
+if TYPE_CHECKING:
+    from langsmith import RunTree
+
+    from ..audio import AudioOutput
+    from ..sdk_tracing import EventSession
+
+
+# Structural bookkeeping events the server sends to track item/content-part
+# lifecycle. They carry no behavioral handler and only duplicate state already
+# captured by `response.done` and the transcript events, so spanning them just
+# floods the trace. Dropped before a span is opened (cf. the `*.delta` skip).
+NOISE_EVENTS = frozenset(
+    {
+        "input_audio_buffer.committed",
+        "conversation.item.added",
+        "conversation.item.done",
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_audio.done",
+        # Redundant with the `model` llm span's tool_calls + the tool span's args.
+        "response.function_call_arguments.done",
+    }
+)
+
+
+class RealtimeTracer:
+    """Turns the Realtime event stream into a LangSmith trace, one event at a time.
+
+    The agent's loop wraps every event in `track_event(event)`; the tracer
+    decides — privately — whether to open a span, open/close a turn, append to
+    the transcript rollup, set the trace title, time first-audio latency, flag a
+    barge-in, and record the `llm` span. All trace writes go through the injected
+    `EventSession`.
+
+    The tracer also holds a *read-only* reference to the speaker (`audio_out`).
+    The wire stream has no "playout finished" event, so the only way to know the
+    agent was still audible when the user spoke (a barge-in) is the speaker's
+    queued-byte count. The tracer only ever reads it; the app owns clearing it.
+    """
+
+    def __init__(self, session: EventSession, audio_out: AudioOutput) -> None:
+        self._session = session
+        self._audio_out = audio_out
+        # Per-turn latency: end-of-user-speech → first agent audio. Armed at
+        # speech_stopped, recorded on the first audio chunk, then cleared.
+        # None = not armed.
+        self._await_audio_since: float | None = None
+
+    @contextmanager
+    def trace_context(self, *, tags: list[str]) -> Iterator[None]:
+        """Session-level LangSmith context (project + tags) for the whole run.
+
+        Wraps the conversation so any traceable calls (e.g. tool execution) land
+        in the right project/thread even outside an open span.
+        """
+        with tracing_context(
+            metadata={"thread_id": self._session.thread_id},
+            tags=tags,
+            project_name=self._session.project_name,
+        ):
+            yield
+
+    @contextmanager
+    def track_event(self, event: Any) -> Iterator[RunTree | None]:
+        """Observe one event and span it where warranted; yields for its handler.
+
+        The body of the `with` is the application's handler for this event. For
+        events that get a span, anything the handler traces (tool execution)
+        nests under it. For events that get no span, the tracer still observes
+        them (latency, transcript, turn boundaries) and yields `None`.
+        """
+        received_at = self._session.now()
+        etype = event.type
+
+        # No-span events: observed for side-state, but never get their own span.
+        if etype == "response.output_audio.delta":
+            self._record_first_audio(received_at)
+            yield None
+            return
+        if etype.endswith(".delta") or etype in NOISE_EVENTS:
+            yield None
+            return
+        if etype == "response.output_audio_transcript.done":
+            # Already the `model` span's content (recorded at response.done);
+            # fold it into the rollup but don't span it twice. The app logs it.
+            self._session.add_message("assistant", event.transcript or "")
+            yield None
+            return
+
+        # Turn boundaries + transcript rollup happen before the span opens.
+        self._before_span(event, received_at)
+
+        with self._session.event_span(
+            event, received_at, name=etype, **self._span_kwargs(event)
+        ) as run:
+            if etype == "conversation.item.input_audio_transcription.failed":
+                # Surface a failed transcription as an errored span so "it didn't
+                # understand me" is debuggable.
+                run.error = f"transcription_failed: {getattr(event, 'error', None)}"
+            elif etype == "response.done":
+                self._record_response_llm(run, event.response)
+            # The app's handler runs here; whatever it traces nests under `run`.
+            with tracing_context(parent=run):
+                yield run
+
+    def _before_span(self, event: Any, received_at: float) -> None:
+        """Turn/transcript/title side-state applied as a span is about to open."""
+        etype = event.type
+        if etype == "input_audio_buffer.speech_started":
+            # A user starting to speak opens a new turn (also the barge-in
+            # signal). If the speaker still has audio queued, the turn being
+            # closed was talked over — flag it before start_turn() closes it.
+            if self._audio_out.buffered_bytes() > 0:
+                self._session.add_turn_metadata(was_interrupted=True)
+            self._session.start_turn()
+            # A new turn supersedes any latency measurement still pending from
+            # the previous turn — discard it so it can't be misattributed.
+            self._await_audio_since = None
+        elif etype == "input_audio_buffer.speech_stopped":
+            # Arm the latency timer: from here to the first agent audio chunk is
+            # the perceived response lag.
+            self._await_audio_since = received_at
+        elif etype == "conversation.item.input_audio_transcription.completed":
+            text = (event.transcript or "").strip()
+            if text:
+                self._session.add_message("user", text)
+                self._session.set_title(text)  # first utterance → trace title
+            else:
+                self._await_audio_since = None  # nothing transcribed
+        elif etype == "conversation.item.input_audio_transcription.failed":
+            self._await_audio_since = None
+
+    def _span_kwargs(self, event: Any) -> dict[str, Any]:
+        """Curated, conversation-shaped I/O for the readable events.
+
+        Everything else keeps its raw wire payload (`event_span`'s default).
+        """
+        etype = event.type
+        kwargs: dict[str, Any] = {"inbound": is_inbound(etype)}
+        if etype == "conversation.item.input_audio_transcription.completed":
+            text = (event.transcript or "").strip()
+            if text:
+                kwargs["inputs"] = {"role": "user", "content": text}
+        elif etype == "response.done":
+            # Keep this span a `chain` wrapper; the model payload (assistant
+            # message, tokens, status) goes on the child `llm` span so local tool
+            # latency in the app's handler is never attributed to the model. The
+            # raw response is still preserved under metadata.raw_event.
+            kwargs["outputs"] = {}
+        return kwargs
+
+    def _record_first_audio(self, received_at: float) -> None:
+        """Record `latency_to_first_audio_ms` on the open turn, once per turn."""
+        if self._await_audio_since is not None:
+            self._session.add_turn_metadata(
+                latency_to_first_audio_ms=round(
+                    (received_at - self._await_audio_since) * 1000
+                )
+            )
+            self._await_audio_since = None
+
+    def _record_response_llm(self, run: RunTree, response: Any) -> None:
+        """Point-in-time `llm` child span for a `response.done` payload."""
+        self._session.record_llm(
+            run,
+            outputs=response_assistant_output(response),
+            usage_metadata=response_usage_metadata(response),
+            metadata={"status": getattr(response, "status", None)},
+        )
+
+
+def is_inbound(event_type: str) -> bool:
+    """Direction of an event relative to the model.
+
+    Inbound = something the user sent toward the model (their speech buffer,
+    their transcription) → goes in span `inputs`. Everything else (`response.*`,
+    `error`, `session.*`) is the model/server talking back → span `outputs`.
+    """
+    return (
+        event_type.startswith("input_audio_buffer")
+        or "input_audio_transcription" in event_type
+    )
+
+
+def _safe_json(raw: str | None) -> Any:
+    """Parse a JSON arguments string, falling back to {} on bad/missing input."""
+    try:
+        return json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def response_assistant_output(response: Any) -> dict[str, Any]:
+    """Curated assistant message from a `response.done` payload.
+
+    Used as the `llm` span's `outputs`: the spoken text the model produced this
+    response, plus any tool calls it requested — the readable, AIMessage-shaped
+    view of what the model returned, rather than the raw wire object.
+    """
+    texts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) == "function_call":
+            tool_calls.append(
+                {
+                    "name": getattr(item, "name", None),
+                    "args": _safe_json(getattr(item, "arguments", None)),
+                    "id": getattr(item, "call_id", None),
+                }
+            )
+            continue
+        for part in getattr(item, "content", None) or []:
+            text = getattr(part, "transcript", None) or getattr(part, "text", None)
+            if text:
+                texts.append(text)
+    out: dict[str, Any] = {"role": "assistant", "content": " ".join(texts).strip()}
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+    return out
+
+
+def response_usage_metadata(response: Any) -> dict[str, int] | None:
+    """Map Realtime token `usage` onto LangSmith `usage_metadata` (for cost).
+
+    Returns None when the response carries no usage (e.g. a cancelled turn), so
+    the caller can skip attaching it.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+
+    def field(key: str) -> int | None:
+        val = getattr(usage, key, None)
+        if val is None and hasattr(usage, "get"):
+            val = usage.get(key)
+        return val
+
+    inp, out, total = (
+        field("input_tokens"),
+        field("output_tokens"),
+        field("total_tokens"),
+    )
+    if inp is None and out is None and total is None:
+        return None
+    return {
+        "input_tokens": inp or 0,
+        "output_tokens": out or 0,
+        "total_tokens": total if total is not None else (inp or 0) + (out or 0),
+    }

--- a/src/voice_demo/openai/utils.py
+++ b/src/voice_demo/openai/utils.py
@@ -1,84 +1,13 @@
-"""Helpers for the OpenAI Realtime agent: tracing glue and tool dispatch."""
+"""Application helpers for the OpenAI Realtime agent: tool dispatch.
+
+Tracing glue lives in `tracing.py`; this module is the application side.
+"""
 
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from .tools import lookup_weather
-
-
-def is_inbound(event_type: str) -> bool:
-    """Direction of an event relative to the model.
-
-    Inbound = something the user sent toward the model (their speech buffer,
-    their transcription) → goes in span `inputs`. Everything else (`response.*`,
-    `error`, `session.*`) is the model/server talking back → span `outputs`.
-    """
-    return event_type.startswith("input_audio_buffer") or "input_audio_transcription" in event_type
-
-
-def _safe_json(raw: str | None) -> Any:
-    """Parse a JSON arguments string, falling back to {} on bad/missing input."""
-    try:
-        return json.loads(raw or "{}")
-    except (json.JSONDecodeError, TypeError):
-        return {}
-
-
-def response_assistant_output(response: Any) -> dict[str, Any]:
-    """Curated assistant message from a `response.done` payload.
-
-    Used as the `llm` span's `outputs`: the spoken text the model produced this
-    response, plus any tool calls it requested — the readable, AIMessage-shaped
-    view of what the model returned, rather than the raw wire object.
-    """
-    texts: list[str] = []
-    tool_calls: list[dict[str, Any]] = []
-    for item in getattr(response, "output", None) or []:
-        if getattr(item, "type", None) == "function_call":
-            tool_calls.append(
-                {
-                    "name": getattr(item, "name", None),
-                    "args": _safe_json(getattr(item, "arguments", None)),
-                    "id": getattr(item, "call_id", None),
-                }
-            )
-            continue
-        for part in getattr(item, "content", None) or []:
-            text = getattr(part, "transcript", None) or getattr(part, "text", None)
-            if text:
-                texts.append(text)
-    out: dict[str, Any] = {"role": "assistant", "content": " ".join(texts).strip()}
-    if tool_calls:
-        out["tool_calls"] = tool_calls
-    return out
-
-
-def response_usage_metadata(response: Any) -> dict[str, int] | None:
-    """Map Realtime token `usage` onto LangSmith `usage_metadata` (for cost).
-
-    Returns None when the response carries no usage (e.g. a cancelled turn), so
-    the caller can skip attaching it.
-    """
-    usage = getattr(response, "usage", None)
-    if usage is None:
-        return None
-
-    def field(key: str) -> int | None:
-        val = getattr(usage, key, None)
-        if val is None and hasattr(usage, "get"):
-            val = usage.get(key)
-        return val
-
-    inp, out, total = field("input_tokens"), field("output_tokens"), field("total_tokens")
-    if inp is None and out is None and total is None:
-        return None
-    return {
-        "input_tokens": inp or 0,
-        "output_tokens": out or 0,
-        "total_tokens": total if total is not None else (inp or 0) + (out or 0),
-    }
 
 
 async def execute_tool(name: str, arguments: str) -> dict:

--- a/src/voice_demo/openai/utils.py
+++ b/src/voice_demo/openai/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from .tools import lookup_weather
 
@@ -15,6 +16,69 @@ def is_inbound(event_type: str) -> bool:
     `error`, `session.*`) is the model/server talking back → span `outputs`.
     """
     return event_type.startswith("input_audio_buffer") or "input_audio_transcription" in event_type
+
+
+def _safe_json(raw: str | None) -> Any:
+    """Parse a JSON arguments string, falling back to {} on bad/missing input."""
+    try:
+        return json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def response_assistant_output(response: Any) -> dict[str, Any]:
+    """Curated assistant message from a `response.done` payload.
+
+    Used as the `llm` span's `outputs`: the spoken text the model produced this
+    response, plus any tool calls it requested — the readable, AIMessage-shaped
+    view of what the model returned, rather than the raw wire object.
+    """
+    texts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) == "function_call":
+            tool_calls.append(
+                {
+                    "name": getattr(item, "name", None),
+                    "args": _safe_json(getattr(item, "arguments", None)),
+                    "id": getattr(item, "call_id", None),
+                }
+            )
+            continue
+        for part in getattr(item, "content", None) or []:
+            text = getattr(part, "transcript", None) or getattr(part, "text", None)
+            if text:
+                texts.append(text)
+    out: dict[str, Any] = {"role": "assistant", "content": " ".join(texts).strip()}
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+    return out
+
+
+def response_usage_metadata(response: Any) -> dict[str, int] | None:
+    """Map Realtime token `usage` onto LangSmith `usage_metadata` (for cost).
+
+    Returns None when the response carries no usage (e.g. a cancelled turn), so
+    the caller can skip attaching it.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+
+    def field(key: str) -> int | None:
+        val = getattr(usage, key, None)
+        if val is None and hasattr(usage, "get"):
+            val = usage.get(key)
+        return val
+
+    inp, out, total = field("input_tokens"), field("output_tokens"), field("total_tokens")
+    if inp is None and out is None and total is None:
+        return None
+    return {
+        "input_tokens": inp or 0,
+        "output_tokens": out or 0,
+        "total_tokens": total if total is not None else (inp or 0) + (out or 0),
+    }
 
 
 async def execute_tool(name: str, arguments: str) -> dict:

--- a/src/voice_demo/openai_agents/agent.py
+++ b/src/voice_demo/openai_agents/agent.py
@@ -25,24 +25,37 @@ the local-machine versions; the agent imports no console code.
 ## Trace shape — one conversation = one trace
 
 Same machinery as the raw backend (`voice_demo.sdk_tracing.EventSession`): one
-root `realtime_session` span with the stereo conversation WAV attached, one child
-span per event. The *difference is what the events are* — the SDK's semantic
-turn/tool/history events rather than the wire protocol's buffer/response events.
-Raw audio (`audio`) is played but not spanned; low-level `raw_model_event`s (the
-SDK's passthrough of the underlying protocol) are dropped as noise — the semantic
-events above already carry the meaning.
+root `realtime_session` span (full transcript in `outputs`, stereo WAV attached)
+grouped into `turn`s.
 
-    realtime_session                                   (root)
+The conversation itself is reconstructed from the **full `history` snapshot** the
+session delivers on every `history_updated` — not from the streamed events, which
+mis-deliver user messages and emit the assistant transcript as growing partials.
+We fold the snapshot into an item map keyed by stable `item_id` (latest text per
+id wins → partials collapse, every user/assistant message is captured), and emit
+one span per message once it's finalized: a curated `user_message` span or an
+assistant `model` (`llm`) span. A new user item opens a `turn`. (Token usage
+isn't available — the SDK has no per-response usage events yet.)
+
+Everything else stays on the live event stream: `tool_start`/`tool_end` (the
+SDK-run tool, a `tool` span), `audio_end`/`agent_*` (the timeline that drives the
+audio-player sync), `latency_to_first_audio_ms`, and `was_interrupted` on
+barge-in. Raw audio (`audio`) isn't spanned; the SDK's `raw_model_event`
+passthrough isn't spanned either, but we mine it for the wire-level input
+transcript that `history` can omit on a barge-in, merging it into the item map.
+
+    realtime_session                                   (root; transcript in outputs)
     │  attachments: conversation.wav                  (stereo: L=user, R=agent)
-    │  metadata: event_count, duration_s
     │
-    ├── agent_start                                   (event)
-    ├── history_added            (user transcript)    (event)
-    ├── tool_start               (lookup_weather)     (event)
-    ├── tool_end                 (weather result)     (event)
-    ├── history_updated          (agent transcript)   (event)
-    ├── audio_interrupted        (barge-in)           (event)
-    └── error                                         (event, if one is raised)
+    ├── turn                                           (metadata: latency_ms, was_interrupted)
+    │   ├── user_message         (user message)       (curated user msg, from history)
+    │   ├── tool_start           (lookup_weather)     (event)
+    │   ├── tool_end             (weather result)     (tool — args in / output out)
+    │   ├── model                (assistant message)  (llm — history; inputs=context, partials collapsed)
+    │   └── audio_interrupted    (barge-in)           (event)
+    └── turn                                           (next user utterance …)
+
+`agent_start`/`agent_end` are dropped (bookkeeping markers with no I/O).
 """
 
 from __future__ import annotations
@@ -51,6 +64,7 @@ import asyncio
 import os
 import sys
 import uuid
+from typing import Any
 
 from agents import set_tracing_disabled
 from agents.realtime import RealtimeAgent, RealtimeRunner
@@ -60,7 +74,13 @@ from ..audio import AudioInput, AudioOutput
 from ..console import NullUI, StatusUI, frame_level
 from ..sdk_tracing import start_session
 from .tools import lookup_weather
-from .utils import describe_event
+from .utils import (
+    HistoryTracker,
+    describe_event,
+    history_item,
+    history_messages,
+    raw_input_transcript,
+)
 
 SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
 weather for any city. Keep replies short, conversational, and free of
@@ -133,14 +153,13 @@ async def run(
         metadata={"thread_id": thread_id, "model": DEFAULT_MODEL},
     )
     mic_task: asyncio.Task | None = None
-    logged: set[tuple[str, str]] = set()
 
-    def log_transcript(role: str | None, text: str | None) -> None:
-        """Surface a user/agent transcript line once (history events repeat)."""
-        if not role or not text or (role, text) in logged:
-            return
-        logged.add((role, text))
-        ui.log(f"{'user: ' if role == 'user' else 'agent:'} {text}")
+    # Authoritative conversation state, reconstructed from the full `history`
+    # snapshot the session delivers on every history event (the streamed events
+    # alone mis-deliver user messages and partials). The tracker folds snapshots
+    # into a per-item map, emits one span per finalized message, groups them into
+    # turns, and owns the per-turn first-audio latency timer.
+    tracker = HistoryTracker(session_trace, ui)
 
     agent = RealtimeAgent(
         name="weather-assistant",
@@ -190,23 +209,63 @@ async def run(
                     # Raw agent audio: many chunks per turn. Play it, don't span
                     # it. The speaker's played-callback records what's heard.
                     if event_type == "audio":
+                        tracker.record_first_audio(received_at)
                         audio_out.write(event.audio.data)
                         ui.set_state("speaking")
                         continue
 
-                    # The SDK's passthrough of the underlying wire protocol —
-                    # noisy and redundant with the semantic events below. Drop it.
+                    # The SDK's passthrough of the underlying wire protocol — noisy,
+                    # not spanned. But it carries the wire-level user transcript that
+                    # the semantic `history` sometimes omits (notably a barge-in), so
+                    # mine that one event and merge it into the item map.
                     if event_type == "raw_model_event":
+                        rec = raw_input_transcript(event)
+                        if rec:
+                            item_id, transcript = rec
+                            tracker.observe([(item_id, "user", transcript)], received_at)
+                            tracker.flush(hold_last=True)
                         continue
 
-                    name, payload, inbound = describe_event(event)
-                    with session_trace.event_span(
-                        payload, received_at, name=name, inbound=inbound
-                    ):
-                        if event_type == "agent_start":
-                            ui.set_state("listening")
+                    # History events feed the authoritative item map; they're not
+                    # spanned directly (they stream partials). Messages are emitted
+                    # as user/`model` spans from the map once an item is finalized.
+                    if event_type == "history_added":
+                        tracker.observe([history_item(event)], received_at)
+                        tracker.flush(hold_last=True)
+                        continue
+                    if event_type == "history_updated":
+                        tracker.observe(history_messages(event), received_at)
+                        tracker.flush(hold_last=True)
+                        continue
 
-                        elif event_type == "audio_interrupted":
+                    # agent_start/agent_end are bookkeeping markers (the agent
+                    # re-activates on each model pass in the tool loop); they carry
+                    # no I/O and just clutter the trace. Keep agent_start's UI cue
+                    # but don't span them.
+                    if event_type == "agent_start":
+                        ui.set_state("listening")
+                        continue
+                    if event_type == "agent_end":
+                        continue
+
+                    # Remaining real-time events: the live timeline (audio-player
+                    # sync), tool runs, latency/barge-in. The full describe_event
+                    # payload is preserved under metadata.raw_event by event_span.
+                    name, payload, inbound = describe_event(event)
+                    span_kwargs: dict[str, Any] = {"inbound": inbound}
+                    if event_type == "tool_end":
+                        # The SDK ran the tool; record it as a `tool` run (args in,
+                        # result out) — a sibling of the assistant `model` span.
+                        span_kwargs["run_type"] = "tool"
+                        span_kwargs["inputs"] = {"arguments": payload.get("arguments")}
+                        span_kwargs["outputs"] = {"output": payload.get("output")}
+                    elif event_type == "audio_interrupted":
+                        session_trace.add_turn_metadata(was_interrupted=True)
+
+                    with session_trace.event_span(
+                        payload, received_at, name=name, **span_kwargs
+                    ):
+                        if event_type == "audio_interrupted":
                             # Barge-in: flush whatever the agent was still saying.
                             audio_out.clear()
                             ui.set_state("hearing you")
@@ -219,12 +278,6 @@ async def run(
 
                         elif event_type == "tool_end":
                             ui.set_state("thinking")
-
-                        elif event_type == "history_added":
-                            log_transcript(payload.get("role"), payload.get("text"))
-
-                        elif event_type == "history_updated":
-                            log_transcript(payload.get("last_role"), payload.get("last_text"))
 
                         elif event_type == "error":
                             ui.log(f"[openai-agents] server error: {payload.get('error')}")
@@ -239,5 +292,8 @@ async def run(
                 mic_task.cancel()
             audio_in.stop()
             audio_out.stop()
+            # Emit any messages still pending when the session ended (e.g. Ctrl-C
+            # mid-utterance) before the turn/root spans close.
+            tracker.flush(hold_last=False)
             session_trace.finalize()
             ui.finish()

--- a/src/voice_demo/openai_agents/agent.py
+++ b/src/voice_demo/openai_agents/agent.py
@@ -22,40 +22,13 @@ Identical to the raw backend: `run()` takes its audio frontend by injection (an
 `AudioInput`, an `AudioOutput`, an optional `StatusUI`). The console CLI supplies
 the local-machine versions; the agent imports no console code.
 
-## Trace shape — one conversation = one trace
+## Tracing is separate
 
-Same machinery as the raw backend (`voice_demo.sdk_tracing.EventSession`): one
-root `realtime_session` span (full transcript in `outputs`, stereo WAV attached)
-grouped into `turn`s.
-
-The conversation itself is reconstructed from the **full `history` snapshot** the
-session delivers on every `history_updated` — not from the streamed events, which
-mis-deliver user messages and emit the assistant transcript as growing partials.
-We fold the snapshot into an item map keyed by stable `item_id` (latest text per
-id wins → partials collapse, every user/assistant message is captured), and emit
-one span per message once it's finalized: a curated `user_message` span or an
-assistant `model` (`llm`) span. A new user item opens a `turn`. (Token usage
-isn't available — the SDK has no per-response usage events yet.)
-
-Everything else stays on the live event stream: `tool_start`/`tool_end` (the
-SDK-run tool, a `tool` span), `audio_end`/`agent_*` (the timeline that drives the
-audio-player sync), `latency_to_first_audio_ms`, and `was_interrupted` on
-barge-in. Raw audio (`audio`) isn't spanned; the SDK's `raw_model_event`
-passthrough isn't spanned either, but we mine it for the wire-level input
-transcript that `history` can omit on a barge-in, merging it into the item map.
-
-    realtime_session                                   (root; transcript in outputs)
-    │  attachments: conversation.wav                  (stereo: L=user, R=agent)
-    │
-    ├── turn                                           (metadata: latency_ms, was_interrupted)
-    │   ├── user_message         (user message)       (curated user msg, from history)
-    │   ├── tool_start           (lookup_weather)     (event)
-    │   ├── tool_end             (weather result)     (tool — args in / output out)
-    │   ├── model                (assistant message)  (llm — history; inputs=context, partials collapsed)
-    │   └── audio_interrupted    (barge-in)           (event)
-    └── turn                                           (next user utterance …)
-
-`agent_start`/`agent_end` are dropped (bookkeeping markers with no I/O).
+This module is the *application*: it wires the mic/speaker to the SDK session
+and reacts to events with UI state. All LangSmith tracing lives in `tracing.py`
+(`HistoryTracker`). The loop wraps each event in `tracker.track_event(event)`
+and its body holds only application side-effects — no span, turn, transcript, or
+metric code. See `tracing.py` for the resulting trace shape.
 """
 
 from __future__ import annotations
@@ -64,23 +37,15 @@ import asyncio
 import os
 import sys
 import uuid
-from typing import Any
 
 from agents import set_tracing_disabled
 from agents.realtime import RealtimeAgent, RealtimeRunner
-from langsmith.run_helpers import tracing_context
 
 from ..audio import AudioInput, AudioOutput
 from ..console import NullUI, StatusUI, frame_level
 from ..sdk_tracing import start_session
 from .tools import lookup_weather
-from .utils import (
-    HistoryTracker,
-    describe_event,
-    history_item,
-    history_messages,
-    raw_input_transcript,
-)
+from .tracing import HistoryTracker
 
 SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
 weather for any city. Keep replies short, conversational, and free of
@@ -171,11 +136,7 @@ async def run(
         config={"model_settings": _model_settings()},
     )
 
-    with tracing_context(
-        metadata={"thread_id": thread_id},
-        tags=["voice-demo", "openai-agents"],
-        project_name=project_name,
-    ):
+    with tracker.trace_context(tags=["voice-demo", "openai-agents"]):
         try:
             session = await runner.run()
             async with session:
@@ -189,7 +150,9 @@ async def run(
 
                 audio_in.start()
                 audio_out.start()
-                ui.log("[openai-agents] connected. Talk into your mic — Ctrl-C to quit.")
+                ui.log(
+                    "[openai-agents] connected. Talk into your mic — Ctrl-C to quit."
+                )
                 ui.set_state("listening")
 
                 async def pump_mic() -> None:
@@ -202,70 +165,23 @@ async def run(
 
                 mic_task = asyncio.create_task(pump_mic())
 
+                # Application event loop. Every event is wrapped in
+                # `tracker.track_event(...)`, which owns all tracing (spans,
+                # turns, transcript, latency); the body below is pure application
+                # behavior — play audio and set UI state.
                 async for event in session:
-                    event_type = event.type
-                    received_at = session_trace.now()
+                    with tracker.track_event(event):
+                        event_type = event.type
 
-                    # Raw agent audio: many chunks per turn. Play it, don't span
-                    # it. The speaker's played-callback records what's heard.
-                    if event_type == "audio":
-                        tracker.record_first_audio(received_at)
-                        audio_out.write(event.audio.data)
-                        ui.set_state("speaking")
-                        continue
+                        if event_type == "audio":
+                            # Many chunks per turn — play each as it arrives.
+                            audio_out.write(event.audio.data)
+                            ui.set_state("speaking")
 
-                    # The SDK's passthrough of the underlying wire protocol — noisy,
-                    # not spanned. But it carries the wire-level user transcript that
-                    # the semantic `history` sometimes omits (notably a barge-in), so
-                    # mine that one event and merge it into the item map.
-                    if event_type == "raw_model_event":
-                        rec = raw_input_transcript(event)
-                        if rec:
-                            item_id, transcript = rec
-                            tracker.observe([(item_id, "user", transcript)], received_at)
-                            tracker.flush(hold_last=True)
-                        continue
+                        elif event_type == "agent_start":
+                            ui.set_state("listening")
 
-                    # History events feed the authoritative item map; they're not
-                    # spanned directly (they stream partials). Messages are emitted
-                    # as user/`model` spans from the map once an item is finalized.
-                    if event_type == "history_added":
-                        tracker.observe([history_item(event)], received_at)
-                        tracker.flush(hold_last=True)
-                        continue
-                    if event_type == "history_updated":
-                        tracker.observe(history_messages(event), received_at)
-                        tracker.flush(hold_last=True)
-                        continue
-
-                    # agent_start/agent_end are bookkeeping markers (the agent
-                    # re-activates on each model pass in the tool loop); they carry
-                    # no I/O and just clutter the trace. Keep agent_start's UI cue
-                    # but don't span them.
-                    if event_type == "agent_start":
-                        ui.set_state("listening")
-                        continue
-                    if event_type == "agent_end":
-                        continue
-
-                    # Remaining real-time events: the live timeline (audio-player
-                    # sync), tool runs, latency/barge-in. The full describe_event
-                    # payload is preserved under metadata.raw_event by event_span.
-                    name, payload, inbound = describe_event(event)
-                    span_kwargs: dict[str, Any] = {"inbound": inbound}
-                    if event_type == "tool_end":
-                        # The SDK ran the tool; record it as a `tool` run (args in,
-                        # result out) — a sibling of the assistant `model` span.
-                        span_kwargs["run_type"] = "tool"
-                        span_kwargs["inputs"] = {"arguments": payload.get("arguments")}
-                        span_kwargs["outputs"] = {"output": payload.get("output")}
-                    elif event_type == "audio_interrupted":
-                        session_trace.add_turn_metadata(was_interrupted=True)
-
-                    with session_trace.event_span(
-                        payload, received_at, name=name, **span_kwargs
-                    ):
-                        if event_type == "audio_interrupted":
+                        elif event_type == "audio_interrupted":
                             # Barge-in: flush whatever the agent was still saying.
                             audio_out.clear()
                             ui.set_state("hearing you")
@@ -280,7 +196,9 @@ async def run(
                             ui.set_state("thinking")
 
                         elif event_type == "error":
-                            ui.log(f"[openai-agents] server error: {payload.get('error')}")
+                            ui.log(
+                                f"[openai-agents] server error: {getattr(event, 'error', None)}"
+                            )
 
         except Exception as exc:
             # Surface unexpected failures (network drop, auth, …) on the root

--- a/src/voice_demo/openai_agents/tracing.py
+++ b/src/voice_demo/openai_agents/tracing.py
@@ -1,22 +1,73 @@
-"""Turn an Agents-SDK realtime session event into a clean span payload.
+"""LangSmith tracing for the OpenAI Agents SDK realtime backend.
 
-The session emits *semantic* events (`agents.realtime.events`) — dataclasses
-holding live SDK objects (the `RealtimeAgent`, tool objects, history items).
-Dumping those wholesale would put unserializable junk on a span, so we walk the
-event recursively and keep everything that reads cleanly while stripping what
-would break or bloat the span: raw audio bytes, callables, private attributes,
-and anything past the depth/width caps (see `_clean`). On top of that generic
-view we overlay a few *promoted* fields per event type (role/text, tool args,
-…) so the most useful data sits at the top level, plus the direction (`inbound`
-= the user talking toward the model → span `inputs`).
+This module owns *everything* that turns the Agents SDK's semantic event stream
+into a LangSmith trace, kept apart from the application logic in `agent.py`: the
+agent's loop wraps each event in `HistoryTracker.track_event(...)` and its body
+holds only application side-effects (play audio, set UI state). All span, turn,
+transcript, and metric decisions live here.
+
+Two layers:
+
+- **Payload shaping.** The session emits *semantic* events
+  (`agents.realtime.events`) — dataclasses holding live SDK objects (the
+  `RealtimeAgent`, tool objects, history items). Dumping those wholesale would
+  put unserializable junk on a span, so `_clean` walks the event recursively,
+  keeping everything that reads cleanly while stripping what would break or
+  bloat the span (raw audio bytes, callables, private attributes, anything past
+  the depth/width caps). `describe_event` overlays a few *promoted* fields per
+  event type (role/text, tool args, …) plus the direction (`inbound`).
+- **`HistoryTracker`.** Reconstructs the conversation from `history` snapshots,
+  emits spans grouped into turns, and routes every event via `track_event`.
+
+## Trace shape — one conversation = one trace
+
+Same machinery as the raw backend (`voice_demo.sdk_tracing.EventSession`): one
+root `realtime_session` span (full transcript in `outputs`, stereo WAV attached)
+grouped into `turn`s.
+
+The conversation is reconstructed from the **full `history` snapshot** the
+session delivers on every `history_updated` — not from the streamed events,
+which mis-deliver user messages and emit the assistant transcript as growing
+partials. We fold the snapshot into an item map keyed by stable `item_id`
+(latest text per id wins → partials collapse, every user/assistant message is
+captured), and emit one span per message once it's finalized: a curated
+`user_message` span or an assistant `model` (`llm`) span. A new user item opens
+a `turn`. (Token usage isn't available — the SDK has no per-response usage
+events yet.)
+
+Everything else stays on the live event stream: `tool_start`/`tool_end` (the
+SDK-run tool, a `tool` span), `audio_end`/`agent_*` (the timeline that drives
+the audio-player sync), `latency_to_first_audio_ms`, and `was_interrupted` on
+barge-in. Raw audio (`audio`) isn't spanned; the SDK's `raw_model_event`
+passthrough isn't spanned either, but we mine it for the wire-level input
+transcript that `history` can omit on a barge-in, merging it into the item map.
+
+    realtime_session                                   (root; transcript in outputs)
+    │  attachments: conversation.wav                  (stereo: L=user, R=agent)
+    │
+    ├── turn                                           (metadata: latency_ms, was_interrupted)
+    │   ├── user_message         (user message)       (curated user msg, from history)
+    │   ├── tool_start           (lookup_weather)     (event)
+    │   ├── tool_end             (weather result)     (tool — args in / output out)
+    │   ├── model                (assistant message)  (llm — history; inputs=context, partials collapsed)
+    │   └── audio_interrupted    (barge-in)           (event)
+    └── turn                                           (next user utterance …)
+
+`agent_start`/`agent_end` are dropped (bookkeeping markers with no I/O).
 """
 
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from langsmith.run_helpers import tracing_context
+
 if TYPE_CHECKING:
+    from langsmith import RunTree
+
     from ..console import StatusUI
     from ..sdk_tracing import EventSession
 
@@ -44,12 +95,16 @@ def _shallow(value: Any) -> Any:
 def _public_fields(value: Any) -> dict[str, Any] | None:
     """Public, non-callable attributes of a dataclass/object, or None."""
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        fields = {f.name: getattr(value, f.name, None) for f in dataclasses.fields(value)}
+        fields = {
+            f.name: getattr(value, f.name, None) for f in dataclasses.fields(value)
+        }
     else:
         fields = getattr(value, "__dict__", None)
     if not fields:
         return None
-    return {k: v for k, v in fields.items() if not k.startswith("_") and not callable(v)}
+    return {
+        k: v for k, v in fields.items() if not k.startswith("_") and not callable(v)
+    }
 
 
 def _clean(value: Any, depth: int = 0, seen: frozenset[int] = frozenset()) -> Any:
@@ -202,7 +257,9 @@ def describe_event(event: Any) -> tuple[str, dict[str, Any], bool]:
         inbound = role == "user"
 
     elif etype == "handoff":
-        payload["from_agent"] = getattr(getattr(event, "from_agent", None), "name", None)
+        payload["from_agent"] = getattr(
+            getattr(event, "from_agent", None), "name", None
+        )
         payload["to_agent"] = getattr(getattr(event, "to_agent", None), "name", None)
 
     elif etype == "guardrail_tripped":
@@ -227,8 +284,14 @@ class HistoryTracker:
     also owns the per-turn first-audio latency timer (armed when a new user turn
     opens, recorded on the first agent audio chunk).
 
-    All trace writes go through the injected `EventSession`; console lines go
-    through the injected `StatusUI`. The tracker does no I/O of its own.
+    All trace writes go through the injected `EventSession`; console lines
+    derived from the reconstructed transcript go through the injected `StatusUI`
+    (the tracker is the only place that knows when a transcript line is new, so
+    that one bit of console output lives here rather than in the app). The
+    tracker does no I/O of its own.
+
+    `track_event` is the single entry point the agent loop calls per event; it
+    routes audio/history/raw/tool/barge-in events to the logic below.
     """
 
     def __init__(self, trace: EventSession, ui: StatusUI) -> None:
@@ -240,6 +303,83 @@ class HistoryTracker:
         self._logged: set[tuple[str, str]] = set()  # (role, text) already printed
         # Per-turn latency: when the current user turn opened; None = not armed.
         self._latency_since: float | None = None
+
+    @contextmanager
+    def trace_context(self, *, tags: list[str]) -> Iterator[None]:
+        """Session-level LangSmith context (project + tags) for the whole run."""
+        with tracing_context(
+            metadata={"thread_id": self._trace.thread_id},
+            tags=tags,
+            project_name=self._trace.project_name,
+        ):
+            yield
+
+    @contextmanager
+    def track_event(self, event: Any) -> Iterator[RunTree | None]:
+        """Observe one session event and span it where warranted.
+
+        The body of the `with` is the application's handler (audio, UI state).
+        Most events are folded into the conversation map or dropped and yield
+        `None`; the remaining live events get a span.
+        """
+        received_at = self._trace.now()
+        etype = event.type
+
+        # Raw agent audio: played by the app, not spanned. Record first-audio
+        # latency on the way through.
+        if etype == "audio":
+            self.record_first_audio(received_at)
+            yield None
+            return
+
+        # The SDK's wire-protocol passthrough — not spanned, but it carries the
+        # wire-level user transcript the semantic `history` sometimes omits
+        # (notably a barge-in). Mine that one event into the item map.
+        if etype == "raw_model_event":
+            rec = raw_input_transcript(event)
+            if rec:
+                item_id, transcript = rec
+                self.observe([(item_id, "user", transcript)], received_at)
+                self.flush(hold_last=True)
+            yield None
+            return
+
+        # History events feed the authoritative item map; not spanned directly
+        # (they stream partials). Messages emit as user/`model` spans from the
+        # map once an item is finalized.
+        if etype == "history_added":
+            self.observe([history_item(event)], received_at)
+            self.flush(hold_last=True)
+            yield None
+            return
+        if etype == "history_updated":
+            self.observe(history_messages(event), received_at)
+            self.flush(hold_last=True)
+            yield None
+            return
+
+        # Bookkeeping markers (the agent re-activates on each model pass in the
+        # tool loop): no I/O, not spanned. The app still reacts to agent_start.
+        if etype in ("agent_start", "agent_end"):
+            yield None
+            return
+
+        # Remaining live events get a span. tool_end becomes a `tool` run; a
+        # barge-in flags the open turn. The full describe_event payload is
+        # preserved under metadata.raw_event by event_span.
+        name, payload, inbound = describe_event(event)
+        span_kwargs: dict[str, Any] = {"inbound": inbound}
+        if etype == "tool_end":
+            span_kwargs["run_type"] = "tool"
+            span_kwargs["inputs"] = {"arguments": payload.get("arguments")}
+            span_kwargs["outputs"] = {"output": payload.get("output")}
+        elif etype == "audio_interrupted":
+            self._trace.add_turn_metadata(was_interrupted=True)
+
+        with self._trace.event_span(
+            payload, received_at, name=name, **span_kwargs
+        ) as run:
+            yield run
 
     def observe(self, seq: list[tuple], received_at: float) -> None:
         """Fold `(item_id, role, text)` tuples into the map.
@@ -282,7 +422,9 @@ class HistoryTracker:
         """Record `latency_to_first_audio_ms` on the open turn, once per turn."""
         if self._latency_since is not None:
             self._trace.add_turn_metadata(
-                latency_to_first_audio_ms=round((received_at - self._latency_since) * 1000)
+                latency_to_first_audio_ms=round(
+                    (received_at - self._latency_since) * 1000
+                )
             )
             self._latency_since = None
 

--- a/src/voice_demo/openai_agents/utils.py
+++ b/src/voice_demo/openai_agents/utils.py
@@ -14,7 +14,11 @@ view we overlay a few *promoted* fields per event type (role/text, tool args,
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..console import StatusUI
+    from ..sdk_tracing import EventSession
 
 _MAX_DEPTH = 4  # how deep we recurse into nested SDK objects before bailing
 _MAX_ITEMS = 50  # cap on collection width so one event never balloons a span
@@ -114,6 +118,47 @@ def _item_text(item: Any) -> tuple[str | None, str | None]:
     return role, (" ".join(parts) or None)
 
 
+def raw_input_transcript(event: Any) -> tuple[str | None, str] | None:
+    """User transcript from a `raw_model_event` wrapping an input-audio
+    transcription completion.
+
+    This is the wire-level source the raw OpenAI backend reads directly. The
+    Agents SDK passes it through as a `raw_model_event`, and it sometimes carries
+    a user utterance the semantic `history` never surfaces (notably a barge-in).
+    Returns `(item_id, transcript)` for a non-empty transcript, else None.
+    """
+    data = getattr(event, "data", None)
+    if getattr(data, "type", None) != "input_audio_transcription_completed":
+        return None
+    transcript = (getattr(data, "transcript", None) or "").strip()
+    if not transcript:
+        return None
+    return getattr(data, "item_id", None), transcript
+
+
+def history_item(event: Any) -> tuple[str | None, str | None, str | None]:
+    """`(item_id, role, text)` for a `history_added` event's single item."""
+    item = getattr(event, "item", None)
+    role, text = _item_text(item)
+    return getattr(item, "item_id", None), role, text
+
+
+def history_messages(event: Any) -> list[tuple[str | None, str | None, str | None]]:
+    """`(item_id, role, text)` for every item in a `history_updated` snapshot.
+
+    The realtime session delivers the full conversation `history` on every
+    update, so this is the authoritative source for the transcript: walking it
+    (rather than the streamed partials) reliably yields *all* user and assistant
+    messages, each with its stable `item_id` so callers can collapse partials by
+    keeping the latest text per id.
+    """
+    out: list[tuple[str | None, str | None, str | None]] = []
+    for item in getattr(event, "history", None) or []:
+        role, text = _item_text(item)
+        out.append((getattr(item, "item_id", None), role, text))
+    return out
+
+
 def describe_event(event: Any) -> tuple[str, dict[str, Any], bool]:
     """Map a session event to `(name, span_payload, inbound)`.
 
@@ -167,3 +212,116 @@ def describe_event(event: Any) -> tuple[str, dict[str, Any], bool]:
         payload["error"] = _stringify(getattr(event, "error", None))
 
     return etype, payload, inbound
+
+
+class HistoryTracker:
+    """Reconstructs the conversation from history snapshots and emits its spans.
+
+    The Agents SDK delivers the full conversation `history` on every history
+    event — the streamed events alone mis-deliver user messages and emit the
+    assistant transcript as growing partials. This tracker folds those snapshots
+    into a map keyed by stable `item_id` (latest non-empty text per id wins, so
+    partials collapse and every user/assistant message is captured) and emits one
+    span per message once it finalizes: a curated `user_message` span or an
+    assistant `model` (`llm`) span, grouped into per-user-turn `turn` spans. It
+    also owns the per-turn first-audio latency timer (armed when a new user turn
+    opens, recorded on the first agent audio chunk).
+
+    All trace writes go through the injected `EventSession`; console lines go
+    through the injected `StatusUI`. The tracker does no I/O of its own.
+    """
+
+    def __init__(self, trace: EventSession, ui: StatusUI) -> None:
+        self._trace = trace
+        self._ui = ui
+        # item_id → {"role", "text"}, in arrival order (dict preserves insertion).
+        self._items: dict[str, dict[str, Any]] = {}
+        self._emitted: set[str] = set()  # item_ids already turned into spans
+        self._logged: set[tuple[str, str]] = set()  # (role, text) already printed
+        # Per-turn latency: when the current user turn opened; None = not armed.
+        self._latency_since: float | None = None
+
+    def observe(self, seq: list[tuple], received_at: float) -> None:
+        """Fold `(item_id, role, text)` tuples into the map.
+
+        A brand-new user item begins a turn: the previous turn's messages are
+        flushed first (so they stay grouped under it), then a new `turn` span
+        opens and the latency timer is armed.
+        """
+        for iid, role, text in seq:
+            if not iid:
+                continue
+            if iid not in self._items and role == "user":
+                self.flush(hold_last=False)
+                self._trace.start_turn()
+                self._latency_since = received_at
+            cur = self._items.get(iid)
+            if cur is None:
+                self._items[iid] = {"role": role, "text": text}
+            else:
+                if role:
+                    cur["role"] = role
+                if text:  # latest non-empty text wins → collapses partials
+                    cur["text"] = text
+            # Print to the console promptly as text arrives (deduped), so the
+            # agent's reply shows immediately — independent of when its span is
+            # emitted (which waits for the item to be superseded).
+            if role in ("user", "assistant") and text:
+                self._log_line(role, text)
+
+    def flush(self, hold_last: bool) -> None:
+        """Emit not-yet-emitted items in order, optionally holding back the last
+        (still-streaming) item until it is superseded or the session ends."""
+        ids = list(self._items)
+        cutoff = len(ids) - 1 if hold_last else len(ids)
+        for iid in ids[: max(0, cutoff)]:
+            if iid not in self._emitted:
+                self._record_item(iid)
+
+    def record_first_audio(self, received_at: float) -> None:
+        """Record `latency_to_first_audio_ms` on the open turn, once per turn."""
+        if self._latency_since is not None:
+            self._trace.add_turn_metadata(
+                latency_to_first_audio_ms=round((received_at - self._latency_since) * 1000)
+            )
+            self._latency_since = None
+
+    def _log_line(self, role: str | None, text: str | None) -> None:
+        """Print one transcript line to the console once.
+
+        Console-only and deduped (history repeats/streams text). Kept separate
+        from the trace transcript (`add_message`) so the console can print
+        promptly as text arrives, while span emission still waits for an item to
+        finalize — otherwise the agent's reply wouldn't print until the next user
+        turn supersedes it.
+        """
+        if not role or not text or (role, text) in self._logged:
+            return
+        self._logged.add((role, text))
+        self._ui.log(f"{'user: ' if role == 'user' else 'agent:'} {text}")
+
+    def _record_item(self, iid: str) -> None:
+        """Emit one message span for a finalized history item (once)."""
+        role = self._items[iid]["role"]
+        text = (self._items[iid]["text"] or "").strip()
+        if role not in ("user", "assistant"):
+            self._emitted.add(iid)  # tool/system items are never messages
+            return
+        if not text:
+            return  # message text not in yet (may arrive late, e.g. a barge-in
+            # transcript recovered from raw_model_event) — leave pending
+        self._emitted.add(iid)
+        self._log_line(role, text)  # console (no-op if already printed promptly)
+        self._trace.add_message(role, text)  # the trace transcript
+        if role == "user":
+            with self._trace.event_span(
+                {"item_id": iid, "role": "user", "content": text},
+                self._trace.now(),
+                name="user_message",
+                inbound=True,
+                inputs={"role": "user", "content": text},
+            ):
+                pass
+        else:
+            # Assistant message → a point-in-time `model` `llm` span under the turn.
+            self._trace.record_llm(outputs={"role": "assistant", "content": text})

--- a/src/voice_demo/sdk_tracing.py
+++ b/src/voice_demo/sdk_tracing.py
@@ -34,10 +34,13 @@ import wave
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, cast
 
 import numpy as np
 from langsmith import RunTree
+
+# The run kinds LangSmith recognizes (matches `RunTree.create_child`).
+RunKind = Literal["tool", "chain", "llm", "retriever", "embedding", "prompt", "parser"]
 
 # Longest string we keep on a span before truncating. Transcripts are short;
 # this only ever trims an unexpectedly large blob.
@@ -162,10 +165,12 @@ def build_stereo_session_wav(
 class EventSession:
     """Conversation-level tracing state. One per process lifetime.
 
-    A conversation doesn't really have inputs/outputs — it *is* the unit of
-    work, so the root span carries roll-up stats in metadata and the stereo
-    conversation WAV as an attachment. Each received event becomes a child span
-    via `event_span()`.
+    The root span carries roll-up stats in metadata, the running conversation
+    transcript as its `outputs` (so the LangSmith preview pane shows the whole
+    exchange at a glance — see `add_message`), and the stereo conversation WAV
+    as an attachment. Each received event becomes a child span via
+    `event_span()` — nested under the current `turn` span if the backend opted
+    into turn grouping (see `start_turn`), otherwise directly under the root.
     """
 
     run: RunTree
@@ -179,10 +184,61 @@ class EventSession:
     user_chunks: list[tuple[float, bytes]] = field(default_factory=list)
     agent_chunks: list[tuple[float, bytes]] = field(default_factory=list)
     event_count: int = 0
+    # Conversation transcript, in turn order: {"role", "content"} per line.
+    # Surfaced as the root span's `outputs` at finalize.
+    messages: list[dict[str, str]] = field(default_factory=list)
+    # Optional turn grouping (see `start_turn`). When a turn is open, event
+    # spans nest under it instead of directly under the root; backends that
+    # never call `start_turn` get the original flat shape unchanged.
+    _current_turn: RunTree | None = field(default=None, init=False)
+    _turn_count: int = field(default=0, init=False)
+    _turn_msg_start: int = field(default=0, init=False)
 
     def now(self) -> float:
         """Seconds since the session started — the timeline used for the WAV."""
         return time.monotonic() - self.t0
+
+    def start_turn(self) -> None:
+        """Open a new conversational-turn span, closing the previous one.
+
+        Subsequent `event_span()` calls nest under this turn until the next
+        `start_turn()` (or `finalize()`). The turn's `outputs` become the
+        transcript lines added during it, so each turn previews its own
+        exchange — mirroring the `turn` spans of the LiveKit/Pipecat backends.
+        Opt-in: a backend that never calls this keeps the flat root layout.
+        """
+        self._close_turn()
+        self._turn_count += 1
+        self._turn_msg_start = len(self.messages)
+        turn = self.run.create_child(
+            name="turn",
+            run_type="chain",
+            inputs={},
+            tags=["turn"],
+            extra={"metadata": {"turn": self._turn_count}},
+        )
+        turn.post()
+        self._current_turn = turn
+
+    def _close_turn(self) -> None:
+        """End the currently open turn span, if any, with its transcript."""
+        if self._current_turn is None:
+            return
+        msgs = self.messages[self._turn_msg_start:]
+        self._current_turn.end(outputs={"messages": msgs} if msgs else {})
+        self._current_turn.patch()
+        self._current_turn = None
+
+    def add_message(self, role: str, content: str) -> None:
+        """Append one transcript line to the conversation rollup.
+
+        Empty/whitespace content is ignored (failed transcriptions, silent
+        turns). Content is truncated like any other span payload (see `scrub`)
+        so an unexpectedly large blob never bloats the root span.
+        """
+        content = (content or "").strip()
+        if content:
+            self.messages.append({"role": role, "content": scrub(content)})
 
     def record_user(self, t: float, data: bytes) -> None:
         self.user_chunks.append((t, data))
@@ -190,9 +246,53 @@ class EventSession:
     def record_agent(self, t: float, data: bytes) -> None:
         self.agent_chunks.append((t, data))
 
+    def set_title(self, text: str) -> None:
+        """Give the conversation root a human-readable title (first one wins).
+
+        Set from the first user utterance so traces are scannable in the project
+        / threads list instead of all reading `realtime_session` — mirroring the
+        `metadata.title` LangSmith carries on agent traces. Scrubbed like any
+        other payload.
+        """
+        text = (text or "").strip()
+        if not text:
+            return
+        extra = self.run.extra or {}
+        metadata = dict(extra.get("metadata") or {})
+        if metadata.get("title"):
+            return  # first non-empty user utterance wins
+        metadata["title"] = scrub(text)
+        extra["metadata"] = metadata
+        self.run.extra = extra
+
+    def add_turn_metadata(self, **kv: Any) -> None:
+        """Merge key/values into the open turn span's metadata (no-op if none).
+
+        For per-turn metrics not known when the turn opens — e.g.
+        `latency_to_first_audio_ms`, `was_interrupted`. Applied to the currently
+        open turn, so call it before the next `start_turn()` closes that turn.
+        """
+        if self._current_turn is None:
+            return
+        extra = self._current_turn.extra or {}
+        metadata = dict(extra.get("metadata") or {})
+        metadata.update(kv)
+        extra["metadata"] = metadata
+        self._current_turn.extra = extra
+
     @contextmanager
     def event_span(
-        self, event: Any, t_now: float, *, name: str, inbound: bool
+        self,
+        event: Any,
+        t_now: float,
+        *,
+        name: str,
+        inbound: bool,
+        run_type: RunKind = "chain",
+        inputs: dict[str, Any] | None = None,
+        outputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> Iterator[RunTree]:
         """Open a child span for one received event; close it on body exit.
 
@@ -200,28 +300,106 @@ class EventSession:
         event (e.g. tool execution) nests inside this span — the same way a tool
         call nests under the LLM step that triggered it in any traced app.
 
-        The event payload lands in `inputs` for user→model (`inbound`) events and
-        in `outputs` for model→user events, so the trace reads in the natural
-        direction of flow.
+        By default the raw (scrubbed) event payload is the span's I/O — in
+        `inputs` for user→model (`inbound`) events, in `outputs` otherwise — so
+        the trace mirrors the wire. Pass curated `inputs`/`outputs` (and
+        optionally a `run_type` like "llm" plus `usage_metadata`) to give the
+        span readable, conversation-shaped I/O instead; the full wire payload is
+        then preserved under `metadata.raw_event` for deep debugging. Curated
+        values pass through `scrub()` (bytes → placeholder, long strings
+        truncated), exactly like the default payload — no un-scrubbed event data
+        ever reaches a span.
         """
         self.event_count += 1
         payload = scrub(dump_event(event))
-        run = self.run.create_child(
+        # "Curated" = the caller supplied readable I/O or a non-default kind, so
+        # the raw wire payload is demoted to metadata rather than the headline.
+        curated = inputs is not None or outputs is not None or run_type != "chain"
+
+        md: dict[str, Any] = {"received_at_s": round(t_now, 3)}
+        if curated:
+            md["raw_event"] = payload
+        if metadata:
+            md.update(metadata)
+
+        if inputs is not None:
+            run_inputs: Any = scrub(inputs)
+        elif curated:
+            run_inputs = {}
+        else:
+            run_inputs = payload if inbound else {}
+
+        parent = self._current_turn or self.run
+        run = parent.create_child(
             name=name,
-            run_type="chain",
-            inputs=payload if inbound else {},
+            run_type=run_type,
+            inputs=run_inputs,
             tags=["event"],
-            extra={"metadata": {"received_at_s": round(t_now, 3)}},
+            extra={"metadata": md},
         )
         run.post()
         try:
             yield run
         finally:
-            run.end(outputs={} if inbound else payload)
+            if usage_metadata is not None:
+                run.set(usage_metadata=cast("Any", usage_metadata))
+            if curated:
+                run.end(outputs=scrub(outputs) if outputs is not None else {})
+            else:
+                run.end(outputs={} if inbound else payload)
             run.patch()
+
+    def record_llm(
+        self,
+        parent: RunTree | None = None,
+        *,
+        name: str = "model",
+        outputs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a point-in-time `llm` child span for a model response payload.
+
+        The voice services deliver a response as a *terminal* event (e.g.
+        Realtime's `response.done`), so there's no model-inference duration to
+        measure — but the token usage, assistant message, and finish status
+        still belong on an `llm`-kind run for cost rollup and readability. Kept
+        point-in-time and separate from the surrounding handler span so local
+        tool latency is never attributed to the model call. Inputs/outputs pass
+        through `scrub()` like any other span payload. `parent` defaults to the
+        current turn (or the root), so callers that group by turn need not thread
+        it.
+
+        When `inputs` is omitted, it defaults to the model's *effective prompt* —
+        the conversation transcript so far minus the response being recorded (the
+        trailing assistant message) — so the `llm` run reads like a normal model
+        call ("given this context → the model said …") instead of having empty
+        inputs.
+        """
+        parent = parent or self._current_turn or self.run
+        if inputs is None:
+            context = list(self.messages)
+            if context and context[-1].get("role") == "assistant":
+                context = context[:-1]  # drop the response we're recording
+            inputs = {"messages": context}
+        run = parent.create_child(
+            name=name,
+            run_type="llm",
+            inputs=scrub(inputs),
+            tags=["model"],
+            extra={"metadata": metadata or {}},
+        )
+        run.post()
+        if usage_metadata is not None:
+            run.set(usage_metadata=cast("Any", usage_metadata))
+        run.end(outputs=scrub(outputs))
+        run.patch()
 
     def finalize(self) -> None:
         """Roll up stats, attach the stereo WAV, and close the root span."""
+        # Close the last open turn (if any) before the root.
+        self._close_turn()
         extra: dict[str, Any] = self.run.extra or {}
         metadata: dict[str, Any] = dict(extra.get("metadata") or {})
         metadata["event_count"] = self.event_count
@@ -236,7 +414,10 @@ class EventSession:
             # One audio asset for the whole conversation — stereo so you can
             # hear both sides AND see interruption overlap.
             self.run.attachments = {"conversation": ("audio/wav", wav)}
-        self.run.end(outputs={})
+        # The transcript is the conversation's natural "output": surfacing it on
+        # the root makes the whole exchange readable in the LangSmith preview
+        # pane without expanding a single child span.
+        self.run.end(outputs={"messages": self.messages} if self.messages else {})
         self.run.patch()
 
 


### PR DESCRIPTION
## What

Reworks how the `openai` and `openai_agents` backends build their LangSmith
traces so a voice conversation reads clearly in the UI. The ADK and OTel
(livekit, pipecat) backends are untouched.

## Before / after

Example traces showing the old vs. new instrumentation (different conversations, illustrative):

**openai backend**
- [Before](https://smith.langchain.com/o/a3866f07-2cf5-4e9c-a287-59ed817c2ecd/projects/p/1b9aaa38-5356-4124-9495-8f244ef9f03d/t/c1ffc258-a64d-4050-b20e-9d8d06d24093) — flat list of raw wire events, no transcript in the preview
- [After](https://smith.langchain.com/o/a3866f07-2cf5-4e9c-a287-59ed817c2ecd/projects/p/1b9aaa38-5356-4124-9495-8f244ef9f03d/t/0fcb917a-0c1c-4b59-9f00-1817b25b039a) — titled, turn-grouped, transcript on the root, `llm` spans with tokens

**openai_agents backend**
- [Before](https://smith.langchain.com/o/a3866f07-2cf5-4e9c-a287-59ed817c2ecd/projects/p/20509e6c-73f7-4880-bf3b-d8964b9957d3/t/4b733612-b6ed-46aa-8bb5-211e0552bb3b)
- [After](https://smith.langchain.com/o/a3866f07-2cf5-4e9c-a287-59ed817c2ecd/projects/p/20509e6c-73f7-4880-bf3b-d8964b9957d3/t/2d8fc09f-a0cb-4f41-828a-eb47e4a0dfc4)

## Shared (`sdk_tracing.EventSession`)

- Conversation transcript surfaced as the root span's `outputs` — the preview pane shows the whole exchange without expanding a child.
- Opt-in **turn grouping**: one user utterance + the agent's full response nest under a `turn` span. Backends that never call `start_turn` keep the flat layout (ADK unchanged).
- `set_title()` puts the first user utterance on `metadata.title` so traces are scannable in the project/threads list.
- `record_llm()`: point-in-time `llm` span for terminal model responses (assistant message + token usage for cost rollup + finish status), with `inputs` defaulting to the effective prompt (context minus the trailing assistant message).
- `event_span()` gains curated, conversation-shaped I/O while preserving the raw wire payload under `metadata.raw_event`.

## `openai` backend

- Drops noisy spans (raw audio, `*.delta` partials, structural-lifecycle `NOISE_EVENTS`).
- `response.done` is a `chain` wrapper holding a child `model` `llm` span, with tool runs as siblings — local tool latency is never attributed to the model call.
- Per-turn `latency_to_first_audio_ms` and `was_interrupted` (barge-in).

## `openai_agents` backend

- Reconstructs the conversation from the authoritative full `history` snapshot (collapsing partials by `item_id`) instead of the streamed events, and mines `raw_model_event` for the barge-in user transcript that `history` can omit. This logic lives in a `HistoryTracker` class.

## Testing

Live-checked both backends end-to-end. The `HistoryTracker` reconstruction is covered by a no-network harness driving the real `EventSession` (multi-turn, partial collapse, barge-in recovery, latency, end-flush).
