### PR TITLE
feat(voice-demo): swap cascade speech providers and add pipecat backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,17 @@
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT_PREFIX=voice-demo
 
-# Used by: both OpenAI Realtime backends (raw + Agents SDK), the LiveKit
-# STT/LLM/TTS cascade and its OpenAI Realtime variant, and both Pipecat backends
-# (STT/LLM/TTS, plus the pipecat-with-langgraph brain).
+# Used by: both OpenAI Realtime backends (raw + Agents SDK), the LLM stage of the
+# LiveKit and Pipecat cascades and their OpenAI Realtime variants, and the
+# pipecat-with-langgraph brain.
 OPENAI_API_KEY=
+
+# Used by: the Pipecat cascade backend — Deepgram STT (Nova) + TTS (Aura).
+DEEPGRAM_API_KEY=
+
+# Used by: the LiveKit cascade backend — AssemblyAI STT + Cartesia TTS.
+ASSEMBLYAI_API_KEY=
+CARTESIA_API_KEY=
 
 # Used by: the Google ADK Live backend and the livekit-with-gemini-live variant.
 GOOGLE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This repo implements a variety of voice agent backends across different framewor
 | `openai` | OpenAI Realtime, raw WebSocket |
 | `openai-agents` | OpenAI Realtime, via the Agents SDK |
 | `adk` | Google ADK Live (Gemini) |
-| `livekit` | LiveKit STT → LLM → TTS cascade |
+| `livekit` | LiveKit STT → LLM → TTS cascade (AssemblyAI STT · OpenAI LLM · Cartesia TTS) |
 | `livekit-with-openai-realtime` | LiveKit, LLM slot swapped for OpenAI Realtime (speech-to-speech) |
 | `livekit-with-gemini-live` | LiveKit, LLM slot swapped for Gemini Live (speech-to-speech) |
-| `pipecat` | Pipecat STT / LLM / TTS (stock OpenAI services) |
+| `pipecat` | Pipecat STT / LLM / TTS (Deepgram STT + Aura TTS · OpenAI LLM) |
 | `pipecat-with-langgraph` | Pipecat, LLM stage is an in-process LangGraph agent |
+| `pipecat-with-openai-realtime` | Pipecat, STT/LLM/TTS cascade swapped for OpenAI Realtime (speech-to-speech) |
+| `pipecat-with-gemini-live` | Pipecat, STT/LLM/TTS cascade swapped for Gemini Live (speech-to-speech) |
 
 Each backend lives in its own self-contained folder under `src/voice_demo/`
 (the `livekit*` and `pipecat*` folders repeat some framework boilerplate on
@@ -46,6 +48,8 @@ uv run voice-demo --backend livekit-with-openai-realtime
 uv run voice-demo --backend livekit-with-gemini-live
 uv run voice-demo --backend pipecat
 uv run voice-demo --backend pipecat-with-langgraph
+uv run voice-demo --backend pipecat-with-openai-realtime
+uv run voice-demo --backend pipecat-with-gemini-live
 ```
 
 Each backend opens your local mic and speaker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "voice-demo"
 version = "0.1.0"
-description = "Voice-agent backends (OpenAI Realtime, Google ADK Live, LiveKit STT/LLM/TTS cascade, LiveKit speech-to-speech with OpenAI Realtime / Gemini Live, Pipecat, and Pipecat with a LangGraph brain), each instrumented for LangSmith the way its framework intends."
+description = "Voice-agent backends (OpenAI Realtime, Google ADK Live, LiveKit STT/LLM/TTS cascade, LiveKit speech-to-speech with OpenAI Realtime / Gemini Live, Pipecat, Pipecat with a LangGraph brain, and Pipecat speech-to-speech with OpenAI Realtime / Gemini Live), each instrumented for LangSmith the way its framework intends."
 requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.0",
@@ -33,21 +33,26 @@ livekit = [
     # Covers all three LiveKit backends (cascade + the two S2S variants).
     # The LangSmith LiveKit integration (span processor + its deps, e.g. cachetools).
     "langsmith[livekit]>=0.9.7",
-    # The agent is LiveKit-native (no LangChain brain): openai = STT/LLM/TTS and
-    # the OpenAI Realtime model; silero/turn-detector = the cascade pipeline.
-    # Floor is 1.6.4: 1.5.18 (the prior resolve) was yanked on PyPI.
-    "livekit-agents[openai,silero,turn-detector]>=1.6.4",
+    # The agent is LiveKit-native (no LangChain brain): the cascade backend uses
+    # assemblyai = STT and cartesia = TTS, openai = the LLM stage (and the
+    # OpenAI Realtime model for the S2S variant); silero/turn-detector = VAD +
+    # end-of-turn detection. Floor is 1.6.4: 1.5.18 (the prior resolve) was
+    # yanked on PyPI.
+    "livekit-agents[assemblyai,cartesia,openai,silero,turn-detector]>=1.6.4",
     # Gemini Live (google.beta.realtime) for the livekit-with-gemini-live backend.
     "livekit-plugins-google>=1.6.4",
 ]
 pipecat = [
-    # Covers both Pipecat backends (stock OpenAI LLM + the LangGraph variant).
+    # Covers all four Pipecat backends: stock OpenAI LLM, the LangGraph variant,
+    # OpenAI Realtime (S2S), and Gemini Live (S2S).
     # The LangSmith Pipecat integration (span processor + its deps, e.g. cachetools).
     "langsmith[pipecat]>=0.9.7",
-    # openai: STT/LLM/TTS services · local: LocalAudioTransport (mic/speaker) ·
-    # tracing: the OTel/setup helpers. Silero VAD ships in pipecat core.
+    # deepgram: STT + Aura TTS for the plain cascade backend · openai: the LLM
+    # stage + OpenAI Realtime services · google: Gemini Live (pulls in
+    # google-genai) · local: LocalAudioTransport (mic/speaker) · tracing: the
+    # OTel/setup helpers. Silero VAD ships in pipecat core.
     # >=1.4: the plain pipecat backend uses FunctionSchema(handler=...), added in 1.4.
-    "pipecat-ai[openai,local,tracing]>=1.4",
+    "pipecat-ai[deepgram,google,local,openai,tracing]>=1.4",
     # The pipecat-with-langgraph backend's "brain" is an in-process LangChain
     # agent (create_agent) over LangGraph. The plain pipecat backend needs none
     # of these.
@@ -56,6 +61,10 @@ pipecat = [
     "langchain-openai>=0.2",
     "langchain-core>=0.3",
 ]
+
+[tool.uv.sources]
+# Use the local langsmith-sdk checkout (editable) instead of the PyPI release.
+langsmith = { path = "../langsmith-sdk/python", editable = true }
 
 [project.scripts]
 voice-demo = "voice_demo.cli:main"

--- a/src/voice_demo/cli.py
+++ b/src/voice_demo/cli.py
@@ -1,11 +1,13 @@
 """Entry point: `voice-demo --backend <name>`.
 
 Backends: openai · openai-agents · adk · livekit · livekit-with-openai-realtime ·
-livekit-with-gemini-live · pipecat · pipecat-with-langgraph. The two
-`livekit-with-*` backends swap LiveKit's STT→LLM→TTS cascade for a
-speech-to-speech realtime model (OpenAI Realtime / Gemini Live); `pipecat` uses
-Pipecat's stock OpenAI LLM service, while `pipecat-with-langgraph` runs an
-in-process LangGraph graph as the LLM stage.
+livekit-with-gemini-live · pipecat · pipecat-with-langgraph ·
+pipecat-with-openai-realtime · pipecat-with-gemini-live. The
+`*-with-openai-realtime` / `*-with-gemini-live` / `livekit-with-*` backends swap
+their framework's STT→LLM→TTS cascade for a speech-to-speech realtime model
+(OpenAI Realtime / Gemini Live); `pipecat` uses Pipecat's stock OpenAI LLM
+service, while `pipecat-with-langgraph` runs an in-process LangGraph graph as the
+LLM stage.
 
 This module is the *frontend*. It owns everything backend-agnostic — argument
 parsing, LangSmith env wiring, and (for the SDK backends) constructing the local
@@ -77,6 +79,8 @@ def main() -> None:
             "livekit-with-gemini-live",
             "pipecat",
             "pipecat-with-langgraph",
+            "pipecat-with-openai-realtime",
+            "pipecat-with-gemini-live",
         ),
         help="Which voice-agent stack to launch.",
     )
@@ -151,6 +155,21 @@ def main() -> None:
         from .pipecat_with_langgraph.agent import run as run_pipecat_langgraph
 
         asyncio.run(run_pipecat_langgraph(project_name=project))
+
+    elif args.backend == "pipecat-with-openai-realtime":
+        # Same Pipecat pipeline, but the STT/LLM/TTS cascade is collapsed into a
+        # single speech-to-speech OpenAI Realtime model in the LLM slot.
+        from .pipecat_with_openai_realtime.agent import run as run_pipecat_realtime
+
+        asyncio.run(run_pipecat_realtime(project_name=project))
+
+    elif args.backend == "pipecat-with-gemini-live":
+        # Same Pipecat pipeline, but the STT/LLM/TTS cascade is collapsed into a
+        # single speech-to-speech Gemini Live model (turns driven by a local VAD
+        # since Gemini Live emits no turn frames of its own).
+        from .pipecat_with_gemini_live.agent import run as run_pipecat_gemini
+
+        asyncio.run(run_pipecat_gemini(project_name=project))
 
 
 if __name__ == "__main__":

--- a/src/voice_demo/livekit/agent.py
+++ b/src/voice_demo/livekit/agent.py
@@ -1,7 +1,8 @@
 """LiveKit voice agent (STT → LLM → TTS cascade), traced via OpenTelemetry.
 
-This is the classic cascade pipeline: OpenAI STT → OpenAI LLM → OpenAI TTS, with
-Silero VAD and multilingual turn detection. For the speech-to-speech variants
+This is the classic cascade pipeline: AssemblyAI STT → OpenAI LLM → Cartesia
+TTS, with Silero VAD and multilingual turn detection. For the speech-to-speech
+variants
 that collapse the whole pipeline into one realtime model, see
 `livekit_with_openai_realtime/` and `livekit_with_gemini_live/` — they share this
 file's tracing wiring, agent, and console entrypoint, differing only in how the
@@ -33,8 +34,13 @@ import sys
 from pathlib import Path
 
 LLM_MODEL = os.getenv("LIVEKIT_LLM_MODEL", "gpt-4o-mini")
-STT_MODEL = os.getenv("LIVEKIT_STT_MODEL", "gpt-4o-mini-transcribe")
-TTS_VOICE = os.getenv("LIVEKIT_TTS_VOICE", "alloy")
+# STT is AssemblyAI, TTS is Cartesia. All three are optional — left unset, each
+# plugin picks its own default: AssemblyAI its default streaming model, Cartesia
+# its default Sonic voice/model. TTS_VOICE is a Cartesia voice id; TTS_MODEL its
+# synthesis model (e.g. "sonic-2").
+STT_MODEL = os.getenv("LIVEKIT_STT_MODEL") or None
+TTS_VOICE = os.getenv("LIVEKIT_TTS_VOICE") or None
+TTS_MODEL = os.getenv("LIVEKIT_TTS_MODEL") or None
 
 # The conversation's thread id is set once per session via the SDK's
 # ``set_thread_id`` (a ContextVar) in the entrypoint; the processor reads it per
@@ -60,7 +66,19 @@ def run(project_name: str) -> None:
     """
     if not os.environ.get("OPENAI_API_KEY"):
         print(
-            "OPENAI_API_KEY is not set (this LiveKit mode needs it for STT/LLM/TTS).",
+            "OPENAI_API_KEY is not set (this LiveKit mode needs it for the LLM stage).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not os.environ.get("ASSEMBLYAI_API_KEY"):
+        print(
+            "ASSEMBLYAI_API_KEY is not set (this LiveKit mode needs it for STT).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not os.environ.get("CARTESIA_API_KEY"):
+        print(
+            "CARTESIA_API_KEY is not set (this LiveKit mode needs it for Cartesia TTS).",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -104,16 +122,30 @@ def run(project_name: str) -> None:
 
     # Plugins must be imported on the main thread (LiveKit registers them at
     # import time), so none of these can be deferred into the job entrypoint.
+    from livekit.plugins import assemblyai
+    from livekit.plugins import cartesia
     from livekit.plugins import openai as lk_openai
     from livekit.plugins import silero
     from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
     def _build_session() -> AgentSession:
-        """The STT → LLM → TTS cascade with VAD and turn detection."""
+        """The STT → LLM → TTS cascade with VAD and turn detection.
+
+        STT is AssemblyAI, TTS is Cartesia; the LLM stage stays OpenAI. Each
+        plugin reads its own key from the environment (ASSEMBLYAI_API_KEY /
+        CARTESIA_API_KEY / OPENAI_API_KEY), all checked at startup above.
+        """
+        # Only pass model/voice when explicitly overridden; otherwise let each
+        # plugin fall back to its own validated default.
+        tts_kwargs = {}
+        if TTS_MODEL:
+            tts_kwargs["model"] = TTS_MODEL
+        if TTS_VOICE:
+            tts_kwargs["voice"] = TTS_VOICE
         return AgentSession(
-            stt=lk_openai.STT(model=STT_MODEL),
+            stt=assemblyai.STT(model=STT_MODEL) if STT_MODEL else assemblyai.STT(),
             llm=lk_openai.LLM(model=LLM_MODEL, temperature=0.3),
-            tts=lk_openai.TTS(model="tts-1", voice=TTS_VOICE),
+            tts=cartesia.TTS(**tts_kwargs),
             vad=silero.VAD.load(),
             # livekit-agents >=1.6 replaced the top-level ``turn_detection`` arg
             # with ``turn_handling=TurnHandlingOptions(...)``.

--- a/src/voice_demo/pipecat/agent.py
+++ b/src/voice_demo/pipecat/agent.py
@@ -1,9 +1,11 @@
 """Pipecat voice agent, traced via OpenTelemetry into LangSmith.
 
-This is the *minimal* Pipecat setup: Pipecat's own `OpenAILLMService` fills the
-LLM slot, with a native Pipecat function tool for the weather lookup. For the
-variant that swaps the LLM stage for an in-process LangGraph "brain" (so every
-graph node nests under the `llm` span), see `pipecat_with_langgraph/`.
+This is the *minimal* Pipecat setup: Deepgram fills the STT and TTS slots
+(`DeepgramSTTService` + `DeepgramTTSService`/Aura) and Pipecat's own
+`OpenAILLMService` fills the LLM slot, with a native Pipecat function tool for
+the weather lookup. For the variant that swaps the LLM stage for an in-process
+LangGraph "brain" (so every graph node nests under the `llm` span), see
+`pipecat_with_langgraph/`.
 
 Why OTEL and not SDK: Pipecat runs the whole STT → LLM → TTS pipeline in-process
 and emits OTel spans for it natively (a `conversation` root, a `turn` span per
@@ -59,8 +61,9 @@ import sys
 import uuid
 
 LLM_MODEL = os.getenv("PIPECAT_LLM_MODEL", "gpt-4o-mini")
-STT_MODEL = os.getenv("PIPECAT_STT_MODEL", "gpt-4o-mini-transcribe")
-TTS_VOICE = os.getenv("PIPECAT_TTS_VOICE", "alloy")
+# STT/TTS are Deepgram: a Nova STT model and an Aura TTS voice.
+STT_MODEL = os.getenv("PIPECAT_STT_MODEL", "nova-3-general")
+TTS_VOICE = os.getenv("PIPECAT_TTS_VOICE", "aura-2-helena-en")
 
 # Per-track bytes buffered before the AudioBufferProcessor emits an `on_audio_data`
 # event. Non-zero so audio streams in periodically and is accumulated before the
@@ -76,7 +79,13 @@ async def run(project_name: str) -> None:
     """
     if not os.environ.get("OPENAI_API_KEY"):
         print(
-            "OPENAI_API_KEY is not set (Pipecat's STT/LLM/TTS need it).",
+            "OPENAI_API_KEY is not set (Pipecat's LLM stage needs it).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not os.environ.get("DEEPGRAM_API_KEY"):
+        print(
+            "DEEPGRAM_API_KEY is not set (Pipecat's Deepgram STT/TTS need it).",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -94,10 +103,10 @@ async def run(project_name: str) -> None:
         LLMUserAggregatorParams,
     )
     from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.deepgram.tts import DeepgramTTSService
     from pipecat.services.llm_service import FunctionCallParams
     from pipecat.services.openai.llm import OpenAILLMService
-    from pipecat.services.openai.stt import OpenAISTTService
-    from pipecat.services.openai.tts import OpenAITTSService
     from pipecat.transports.local.audio import (
         LocalAudioTransport,
         LocalAudioTransportParams,
@@ -144,11 +153,21 @@ async def run(project_name: str) -> None:
         LocalAudioTransportParams(audio_in_enabled=True, audio_out_enabled=True)
     )
 
-    stt = OpenAISTTService(settings=OpenAISTTService.Settings(model=STT_MODEL))
+    # Deepgram STT/TTS take their API key explicitly (no env-var fallback); the
+    # startup check above guarantees it is present. Deepgram Aura treats the
+    # voice name as the model, so the TTS voice fully picks the speaker.
+    deepgram_api_key = os.environ["DEEPGRAM_API_KEY"]
+    stt = DeepgramSTTService(
+        api_key=deepgram_api_key,
+        settings=DeepgramSTTService.Settings(model=STT_MODEL),
+    )
     llm = OpenAILLMService(
         settings=OpenAILLMService.Settings(model=LLM_MODEL, temperature=0.3)
     )
-    tts = OpenAITTSService(settings=OpenAITTSService.Settings(voice=TTS_VOICE))
+    tts = DeepgramTTSService(
+        api_key=deepgram_api_key,
+        settings=DeepgramTTSService.Settings(voice=TTS_VOICE),
+    )
 
     # A native Pipecat function tool. The handler receives FunctionCallParams and
     # returns its result through result_callback. Because the schema carries the

--- a/src/voice_demo/pipecat/agent.py
+++ b/src/voice_demo/pipecat/agent.py
@@ -8,7 +8,7 @@ graph node nests under the `llm` span), see `pipecat_with_langgraph/`.
 Why OTEL and not SDK: Pipecat runs the whole STT → LLM → TTS pipeline in-process
 and emits OTel spans for it natively (a `conversation` root, a `turn` span per
 exchange, and `stt` / `llm` / `tts` child spans), gated behind
-`PipelineTask(enable_tracing=True, enable_turn_tracking=True)`. The framework
+`PipelineWorker(enable_tracing=True, enable_turn_tracking=True)`. The framework
 does the hard work; we just call `configure_pipecat` (the LangSmith voice
 integration, `langsmith.integrations.pipecat`), which installs a span processor
 that rewrites those spans into the `gen_ai.*` / `langsmith.*` namespaces
@@ -86,8 +86,8 @@ async def run(project_name: str) -> None:
     from pipecat.audio.vad.silero import SileroVADAnalyzer
     from pipecat.frames.frames import TTSSpeakFrame
     from pipecat.pipeline.pipeline import Pipeline
-    from pipecat.pipeline.runner import PipelineRunner
-    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+    from pipecat.workers.runner import WorkerRunner
     from pipecat.processors.aggregators.llm_context import LLMContext
     from pipecat.processors.aggregators.llm_response_universal import (
         LLMContextAggregatorPair,
@@ -203,7 +203,7 @@ async def run(project_name: str) -> None:
         ]
     )
 
-    task = PipelineTask(
+    worker = PipelineWorker(
         pipeline,
         params=PipelineParams(enable_metrics=True),
         enable_tracing=True,
@@ -216,12 +216,13 @@ async def run(project_name: str) -> None:
     # the assistant's opening message so the model has context on the next turn.
     # Mirrors the LiveKit backend's session.say(GREETING). It adds no `llm` span,
     # so the conversation root aggregates from the first real user turn onward.
-    await task.queue_frames([TTSSpeakFrame(text=GREETING, append_to_context=True)])
+    await worker.queue_frames([TTSSpeakFrame(text=GREETING, append_to_context=True)])
 
     # Begin recording. start_recording() only flips a flag and resets buffers (no
     # sample-rate dependency); the StartFrame sets the rate before any audio flows.
     await audiobuffer.start_recording()
 
     logger.info("[pipecat] connected — say something (Ctrl-C to quit).")
-    runner = PipelineRunner(handle_sigint=False if sys.platform == "win32" else True)
-    await runner.run(task)
+    runner = WorkerRunner(handle_sigint=False if sys.platform == "win32" else True)
+    await runner.add_workers(worker)
+    await runner.run()

--- a/src/voice_demo/pipecat_with_gemini_live/__init__.py
+++ b/src/voice_demo/pipecat_with_gemini_live/__init__.py
@@ -1,0 +1,12 @@
+"""Pipecat voice-agent backend whose LLM stage is Gemini Live (S2S).
+
+This is the `pipecat` cascade backend with its STT → LLM → TTS trio collapsed
+into a single speech-to-speech model: Pipecat's `GeminiLiveLLMService` ingests
+the user's audio and emits the bot's audio directly. It is the Gemini twin of
+`pipecat_with_openai_realtime/`, with one structural difference: Gemini Live
+doesn't emit user turn-start/-end frames from its server-side VAD, so this
+backend drives turns with a *local* Silero VAD (and disables Gemini's server
+VAD) to keep the LangSmith `turn` spans and turn-based barge-in that the tracing
+demo depends on. See `pipecat_with_gemini_live/agent.py` for the full rationale
+and `pipecat/agent.py` for the shared tracing/recording commentary.
+"""

--- a/src/voice_demo/pipecat_with_gemini_live/agent.py
+++ b/src/voice_demo/pipecat_with_gemini_live/agent.py
@@ -1,0 +1,249 @@
+"""Pipecat voice agent with a Gemini Live (S2S) LLM stage, traced into LangSmith.
+
+This is the `pipecat` cascade backend with its STT → LLM → TTS trio replaced by
+a single speech-to-speech model. `GeminiLiveLLMService` speaks WebSocket to
+Google's Gemini Live API: it takes the user's mic audio in and streams the bot's
+spoken audio out, so there is no separate STT / TTS stage — just the one `llm`
+span for the Gemini Live model. It is the Gemini twin of
+`pipecat_with_openai_realtime/agent.py`; read that file and `pipecat/agent.py`
+first — only the Gemini-specific differences are called out here.
+
+Why OTEL and not SDK: unchanged from the cascade — Pipecat emits the OTel spans
+(`conversation` root, a `turn` per exchange, an `llm` child) and
+`configure_pipecat` (the LangSmith Pipecat integration) rewrites them into the
+`gen_ai.*` / `langsmith.*` shape. The `llm` span here is a real Gemini inference
+span, so we keep the default `llm_span_kind="llm"`.
+
+## Turn detection: LOCAL VAD, unlike the OpenAI Realtime twin
+
+This is *the* difference from `pipecat_with_openai_realtime/`. OpenAI Realtime
+emits `UserStartedSpeakingFrame` / `UserStoppedSpeakingFrame` from its
+server-side VAD, so that backend needs no local VAD. **Gemini Live does not** —
+its API exposes an `interrupted` event but no turn-start/-end signals. Pipecat's
+`TurnTrackingObserver` opens a turn on `UserStartedSpeakingFrame`, so with
+Gemini's server-VAD-only setup there would be no user-turn frames, hence no
+`turn` spans and no turn-based barge-in — gutting the very thing this repo is
+here to show.
+
+So we run Gemini Live in *locally-driven-turns* mode:
+
+  * Disable Gemini's server VAD (`GeminiVADParams(disabled=True)`).
+  * Attach a local `SileroVADAnalyzer` to the user aggregator. It emits the
+    user-turn frames, which the `TurnTrackingObserver` turns into `turn` spans
+    and which the service converts into Gemini `activity_start` / `activity_end`
+    signals so the model knows when the user's turn begins and ends.
+
+The trade-off (a fair teaching point): local turn boundaries are a VAD heuristic
+and may not match what Gemini's own server-side VAD would have decided. We still
+pair the aggregators with `realtime_service_mode=True` — Gemini Live is a
+continuously-running S2S service, so context writes must follow the content
+stream rather than the turn frames.
+
+## Tools
+
+Identical to the other Pipecat backends: `lookup_weather` is a `FunctionSchema`
+carrying its own handler, so advertising it on `LLMContext(tools=[...])`
+auto-registers it and Pipecat runs the tool loop over the Gemini WebSocket.
+
+## Greeting
+
+Like the OpenAI Realtime twin, there is no TTS stage to speak a fixed string, so
+the seeded system message asks the model to open with the exact greeting.
+`GeminiLiveLLMService` generates a response when its context is first set
+(`inference_on_context_initialization=True`, the default), so kicking the first
+turn with an `LLMRunFrame` makes the model speak the greeting itself.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+# The Gemini Live model (a native-audio S2S model) and the voice it speaks in.
+# "Puck" matches the LiveKit Gemini backend. The default model tracks Pipecat's
+# own default so it's known-valid for the installed pipecat version.
+GEMINI_MODEL = os.getenv(
+    "PIPECAT_GEMINI_MODEL", "models/gemini-2.5-flash-native-audio-preview-12-2025"
+)
+GEMINI_VOICE = os.getenv("PIPECAT_GEMINI_VOICE", "Puck")
+
+# Per-track bytes buffered before the AudioBufferProcessor emits `on_audio_data`.
+# Non-zero so audio streams in and is accumulated before the conversation span
+# exports (the default 0 emits only once, at stop). See pipecat/agent.py.
+AUDIO_BUFFER_SIZE = 32_000
+
+
+async def run(project_name: str) -> None:
+    """Build and run the Pipecat + Gemini Live pipeline with LangSmith tracing.
+
+    Blocks until Ctrl-C. `project_name` is the LangSmith project the trace lands
+    in (passed to `configure_pipecat`).
+    """
+    if not os.environ.get("GOOGLE_API_KEY"):
+        print(
+            "GOOGLE_API_KEY is not set (the Gemini Live model needs it).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from loguru import logger
+    from pipecat.adapters.schemas.function_schema import FunctionSchema
+    from pipecat.audio.vad.silero import SileroVADAnalyzer
+    from pipecat.frames.frames import LLMRunFrame
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+    from pipecat.processors.aggregators.llm_context import LLMContext
+    from pipecat.processors.aggregators.llm_response_universal import (
+        LLMContextAggregatorPair,
+        LLMUserAggregatorParams,
+    )
+    from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+    from pipecat.services.google.gemini_live.llm import (
+        GeminiLiveLLMService,
+        GeminiModalities,
+        GeminiVADParams,
+    )
+    from pipecat.services.llm_service import FunctionCallParams
+    from pipecat.transports.local.audio import (
+        LocalAudioTransport,
+        LocalAudioTransportParams,
+    )
+    from pipecat.workers.runner import WorkerRunner
+
+    from ..prompts import GREETING, SYSTEM_PROMPT
+    from ..weather import fetch_weather
+    from langsmith.integrations.pipecat import configure_pipecat, set_thread_id
+
+    conversation_id = str(uuid.uuid4())
+    # Bind the thread id in this conversation's context (a ContextVar the span
+    # processor reads per span). See pipecat/agent.py for why this scales to
+    # concurrent conversations where a shared closure would not.
+    set_thread_id(conversation_id)
+
+    # Wire the OTel → LangSmith span processor. Same as the cascade: keep the
+    # default llm_span_kind="llm" — here the `llm` span is a real Gemini Live
+    # inference call. configure_pipecat resolves the LangSmith exporter config
+    # from the standard LANGSMITH_* env, so we only call it when a key is present.
+    span_processor = (
+        configure_pipecat(
+            project=project_name,
+            service_name="voice-demo-pipecat-gemini-live",
+        )
+        if os.environ.get("LANGSMITH_API_KEY")
+        else None
+    )
+    if span_processor is not None:
+        logger.info(
+            f"[pipecat-gemini-live] LangSmith tracing enabled · project={project_name}"
+        )
+    else:
+        logger.info(
+            "[pipecat-gemini-live] LANGSMITH_API_KEY not set — running without tracing."
+        )
+    logger.info(f"[pipecat-gemini-live] conversation_id={conversation_id}")
+
+    transport = LocalAudioTransport(
+        LocalAudioTransportParams(audio_in_enabled=True, audio_out_enabled=True)
+    )
+
+    # The single speech-to-speech service that fills the STT+LLM+TTS slot. We
+    # disable Gemini's server-side VAD (vad=disabled) and drive turns with a
+    # local Silero VAD instead — see the "Turn detection" note in the module
+    # docstring. The system instructions and tools come from the LLMContext below
+    # (the service reads the context's system message as its instructions).
+    llm = GeminiLiveLLMService(
+        api_key=os.environ["GOOGLE_API_KEY"],
+        settings=GeminiLiveLLMService.Settings(
+            model=GEMINI_MODEL,
+            voice=GEMINI_VOICE,
+            modalities=GeminiModalities.AUDIO,
+            vad=GeminiVADParams(disabled=True),
+        ),
+    )
+
+    # A native Pipecat function tool — identical to the other Pipecat backends.
+    # Because the schema carries the handler, advertising it on the LLMContext
+    # auto-registers it and Pipecat runs the tool loop over the Gemini WebSocket.
+    async def lookup_weather(params: FunctionCallParams) -> None:
+        weather = await fetch_weather(params.arguments["city"])
+        await params.result_callback(weather)
+
+    weather_tool = FunctionSchema(
+        name="lookup_weather",
+        description="Get the current weather for a single city. Call once per city.",
+        properties={
+            "city": {"type": "string", "description": "City name, e.g. 'Paris'."}
+        },
+        required=["city"],
+        handler=lookup_weather,
+    )
+
+    # Seed the context with the shared system prompt plus a one-time directive to
+    # open with the exact greeting (a realtime model has no TTS stage to speak a
+    # fixed string, so it says the opener itself). The service reads this system
+    # message as the session instructions.
+    context = LLMContext(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    f"{SYSTEM_PROMPT}\n\n"
+                    f'To begin, greet the user by saying exactly: "{GREETING}"'
+                ),
+            }
+        ],
+        tools=[weather_tool],
+    )
+    # Local VAD on the user aggregator supplies the user-turn frames (Gemini Live
+    # doesn't emit them); realtime_service_mode=True keeps context writes driven
+    # by the content stream, as required for a continuously-running S2S service.
+    context_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+        realtime_service_mode=True,
+    )
+
+    # Pipecat's official recorder: stereo (user left, bot right), placed after
+    # transport.output() so it taps the bot audio as actually played plus the
+    # user's mic. The span processor reads its `on_audio_data` events and attaches
+    # the WAV to the root span. See pipecat/agent.py.
+    audiobuffer = AudioBufferProcessor(num_channels=2, buffer_size=AUDIO_BUFFER_SIZE)
+    if span_processor is not None:
+        span_processor.attach_audio_buffer(audiobuffer, conversation_id)
+
+    # No stt/tts stages: the Gemini Live `llm` sits directly between the
+    # transport's mic in and speaker out.
+    pipeline = Pipeline(
+        [
+            transport.input(),  # mic in
+            context_aggregator.user(),  # add user msg to context
+            llm,  # speech in → speech out (+ tool calls)
+            transport.output(),  # speaker out
+            audiobuffer,  # record what was heard (after output)
+            context_aggregator.assistant(),  # add assistant msg to context
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(enable_metrics=True),
+        enable_tracing=True,
+        enable_turn_tracking=True,  # required for tracing; records was_interrupted
+        conversation_id=conversation_id,
+    )
+
+    # Begin recording before any audio flows. start_recording() only flips a flag
+    # and resets buffers; the StartFrame sets the sample rate.
+    await audiobuffer.start_recording()
+
+    # Kick the opening turn: the aggregator pushes the initial context, and the
+    # Gemini Live service generates a response on first context
+    # (inference_on_context_initialization=True) — the model speaks the greeting
+    # seeded above.
+    await worker.queue_frames([LLMRunFrame()])
+
+    logger.info("[pipecat-gemini-live] connected — say something (Ctrl-C to quit).")
+    runner = WorkerRunner(handle_sigint=False if sys.platform == "win32" else True)
+    await runner.add_workers(worker)
+    await runner.run()

--- a/src/voice_demo/pipecat_with_openai_realtime/__init__.py
+++ b/src/voice_demo/pipecat_with_openai_realtime/__init__.py
@@ -1,0 +1,13 @@
+"""Pipecat voice-agent backend whose LLM stage is OpenAI Realtime (S2S).
+
+This is the `pipecat` cascade backend with its STT → LLM → TTS trio collapsed
+into a single speech-to-speech model: Pipecat's `OpenAIRealtimeLLMService`
+ingests the user's audio and emits the bot's audio directly, so there is no
+separate STT or TTS stage and no local VAD — OpenAI's server-side turn
+detection drives the turns. Everything else (the OTel → LangSmith tracing
+wiring, the native Pipecat function tool, the recorder) is the same as the
+cascade; see `pipecat/agent.py` for the fully-commented version.
+
+See `pipecat_with_langgraph/` for the variant that keeps the STT/TTS cascade but
+swaps the *text* LLM stage for an in-process LangGraph graph.
+"""

--- a/src/voice_demo/pipecat_with_openai_realtime/agent.py
+++ b/src/voice_demo/pipecat_with_openai_realtime/agent.py
@@ -1,0 +1,239 @@
+"""Pipecat voice agent with an OpenAI Realtime (S2S) LLM stage, traced into LangSmith.
+
+This is the `pipecat` cascade backend with its STT → LLM → TTS trio replaced by
+a single speech-to-speech model. `OpenAIRealtimeLLMService` speaks WebSocket to
+OpenAI's Realtime API: it takes the user's mic audio in and streams the bot's
+spoken audio out, so there is no separate `OpenAISTTService` / `OpenAITTSService`
+stage and no `stt` / `tts` span — just the one `llm` span for the realtime model.
+For the fully-commented tracing/recording rationale shared with this file, read
+`pipecat/agent.py`; only the realtime-specific differences are called out here.
+
+Why OTEL and not SDK: unchanged from the cascade. Pipecat emits OTel spans for
+the pipeline natively (a `conversation` root, a `turn` per exchange, and an `llm`
+child), gated behind `PipelineWorker(enable_tracing=True,
+enable_turn_tracking=True)`. `configure_pipecat` (the LangSmith Pipecat
+integration) installs the span processor that rewrites those into the
+`gen_ai.*` / `langsmith.*` namespaces and attaches the recorded audio. The `llm`
+span here is a real OpenAI inference span (the realtime model *is* the
+inference), so we keep `configure_pipecat`'s default `llm_span_kind="llm"` —
+unlike the LangGraph variant, which overrides it to `"chain"`.
+
+## Turn detection (no local VAD)
+
+The realtime service runs on OpenAI's *server-side* VAD: it emits
+`UserStartedSpeakingFrame` / `UserStoppedSpeakingFrame` from the model's own
+turn-detection events, which also drive barge-in. So, unlike the cascade, we
+attach no `SileroVADAnalyzer` — a second local VAD would double-broadcast
+user-turn frames. We pair the aggregators with `realtime_service_mode=True` so
+context writes are driven by the content stream (transcripts,
+`LLMFullResponseStartFrame`) instead of those turn frames, which is how the
+universal aggregator supports a continuously-running S2S model.
+
+## Tools
+
+Identical to the cascade: `lookup_weather` is a `FunctionSchema` that carries its
+own handler, so advertising it on `LLMContext(tools=[...])` auto-registers it.
+Pipecat owns the tool loop — the realtime model requests the call, Pipecat runs
+the handler and feeds the result back over the WebSocket, and the call/result
+land in the context so the model sees its own prior tool usage on later turns.
+
+## Greeting
+
+Realtime models have no TTS stage to synthesize a fixed string, so the cascade's
+`TTSSpeakFrame(GREETING)` trick doesn't apply (mirroring the LiveKit realtime
+backend, where `supports_say` is False). Instead the seeded system message asks
+the model to open with the exact greeting, and we kick the first turn with an
+`LLMRunFrame`: the aggregator pushes the initial context, and the service
+auto-creates the opening response — the model speaks the greeting itself.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+# Connection-level realtime model (set on the WebSocket URL; can't change mid-session)
+# and the voice the model speaks in. "marin" matches the LiveKit realtime backend.
+REALTIME_MODEL = os.getenv("PIPECAT_REALTIME_MODEL", "gpt-realtime")
+REALTIME_VOICE = os.getenv("PIPECAT_REALTIME_VOICE", "marin")
+
+# Per-track bytes buffered before the AudioBufferProcessor emits `on_audio_data`.
+# Non-zero so audio streams in and is accumulated before the conversation span
+# exports (the default 0 emits only once, at stop). See pipecat/agent.py.
+AUDIO_BUFFER_SIZE = 32_000
+
+
+async def run(project_name: str) -> None:
+    """Build and run the Pipecat + OpenAI Realtime pipeline with LangSmith tracing.
+
+    Blocks until Ctrl-C. `project_name` is the LangSmith project the trace lands
+    in (passed to `configure_pipecat`).
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        print(
+            "OPENAI_API_KEY is not set (the OpenAI Realtime model needs it).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from loguru import logger
+    from pipecat.adapters.schemas.function_schema import FunctionSchema
+    from pipecat.frames.frames import LLMRunFrame
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+    from pipecat.processors.aggregators.llm_context import LLMContext
+    from pipecat.processors.aggregators.llm_response_universal import (
+        LLMContextAggregatorPair,
+    )
+    from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+    from pipecat.services.llm_service import FunctionCallParams
+    from pipecat.services.openai.realtime.events import (
+        AudioConfiguration,
+        AudioOutput,
+        SessionProperties,
+    )
+    from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+    from pipecat.transports.local.audio import (
+        LocalAudioTransport,
+        LocalAudioTransportParams,
+    )
+    from pipecat.workers.runner import WorkerRunner
+
+    from ..prompts import GREETING, SYSTEM_PROMPT
+    from ..weather import fetch_weather
+    from langsmith.integrations.pipecat import configure_pipecat, set_thread_id
+
+    conversation_id = str(uuid.uuid4())
+    # Bind the thread id in this conversation's context (a ContextVar the span
+    # processor reads per span). See pipecat/agent.py for why this scales to
+    # concurrent conversations where a shared closure would not.
+    set_thread_id(conversation_id)
+
+    # Wire the OTel → LangSmith span processor. Same as the cascade: keep the
+    # default llm_span_kind="llm" — here the `llm` span is a real OpenAI Realtime
+    # inference call. configure_pipecat resolves the LangSmith exporter config
+    # from the standard LANGSMITH_* env, so we only call it when a key is present.
+    span_processor = (
+        configure_pipecat(
+            project=project_name,
+            service_name="voice-demo-pipecat-openai-realtime",
+        )
+        if os.environ.get("LANGSMITH_API_KEY")
+        else None
+    )
+    if span_processor is not None:
+        logger.info(
+            f"[pipecat-openai-realtime] LangSmith tracing enabled · project={project_name}"
+        )
+    else:
+        logger.info(
+            "[pipecat-openai-realtime] LANGSMITH_API_KEY not set — running without tracing."
+        )
+    logger.info(f"[pipecat-openai-realtime] conversation_id={conversation_id}")
+
+    transport = LocalAudioTransport(
+        LocalAudioTransportParams(audio_in_enabled=True, audio_out_enabled=True)
+    )
+
+    # The single speech-to-speech service that fills the STT+LLM+TTS slot. The
+    # voice is set via the session's audio-output config; the system instructions
+    # and tools come from the LLMContext below (the service reads the context's
+    # system message as its session instructions). Server-side turn detection is
+    # on by default, which is what emits the user-speaking frames and handles
+    # barge-in — so we add no local VAD.
+    llm = OpenAIRealtimeLLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAIRealtimeLLMService.Settings(
+            model=REALTIME_MODEL,
+            session_properties=SessionProperties(
+                audio=AudioConfiguration(output=AudioOutput(voice=REALTIME_VOICE)),
+            ),
+        ),
+    )
+
+    # A native Pipecat function tool — identical to the cascade. The handler
+    # receives FunctionCallParams and returns via result_callback; because the
+    # schema carries the handler, advertising it on the LLMContext auto-registers
+    # it and Pipecat runs the tool loop over the realtime WebSocket.
+    async def lookup_weather(params: FunctionCallParams) -> None:
+        weather = await fetch_weather(params.arguments["city"])
+        await params.result_callback(weather)
+
+    weather_tool = FunctionSchema(
+        name="lookup_weather",
+        description="Get the current weather for a single city. Call once per city.",
+        properties={
+            "city": {"type": "string", "description": "City name, e.g. 'Paris'."}
+        },
+        required=["city"],
+        handler=lookup_weather,
+    )
+
+    # Seed the context with the shared system prompt plus a one-time directive to
+    # open with the exact greeting (see the "Greeting" note in the module
+    # docstring — a realtime model has no TTS stage to speak a fixed string, so
+    # it says the opener itself). The service reads this system message as the
+    # session instructions.
+    context = LLMContext(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    f"{SYSTEM_PROMPT}\n\n"
+                    f'To begin, greet the user by saying exactly: "{GREETING}"'
+                ),
+            }
+        ],
+        tools=[weather_tool],
+    )
+    # realtime_service_mode=True: context writes follow the content stream, not
+    # turn frames, and no VAD analyzer on the user aggregator (the realtime
+    # service supplies the user-turn frames from server-side VAD).
+    context_aggregator = LLMContextAggregatorPair(
+        context, realtime_service_mode=True
+    )
+
+    # Pipecat's official recorder: stereo (user left, bot right), placed after
+    # transport.output() so it taps the bot audio as actually played plus the
+    # user's mic. The span processor reads its `on_audio_data` events and attaches
+    # the WAV to the root span. See pipecat/agent.py.
+    audiobuffer = AudioBufferProcessor(num_channels=2, buffer_size=AUDIO_BUFFER_SIZE)
+    if span_processor is not None:
+        span_processor.attach_audio_buffer(audiobuffer, conversation_id)
+
+    # No stt/tts stages: the realtime `llm` sits directly between the transport's
+    # mic in and speaker out.
+    pipeline = Pipeline(
+        [
+            transport.input(),  # mic in
+            context_aggregator.user(),  # add user msg to context
+            llm,  # speech in → speech out (+ tool calls)
+            transport.output(),  # speaker out
+            audiobuffer,  # record what was heard (after output)
+            context_aggregator.assistant(),  # add assistant msg to context
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(enable_metrics=True),
+        enable_tracing=True,
+        enable_turn_tracking=True,  # required for tracing; records was_interrupted
+        conversation_id=conversation_id,
+    )
+
+    # Begin recording before any audio flows. start_recording() only flips a flag
+    # and resets buffers; the StartFrame sets the sample rate.
+    await audiobuffer.start_recording()
+
+    # Kick the opening turn: the aggregator pushes the initial context, and the
+    # realtime service auto-creates a response — the model speaks the greeting
+    # seeded above. (There's no TTSSpeakFrame here; a realtime model has no TTS
+    # stage to synthesize a fixed string.)
+    await worker.queue_frames([LLMRunFrame()])
+
+    logger.info("[pipecat-openai-realtime] connected — say something (Ctrl-C to quit).")
+    runner = WorkerRunner(handle_sigint=False if sys.platform == "win32" else True)
+    await runner.add_workers(worker)
+    await runner.run()

--- a/src/voice_demo/tracing.py
+++ b/src/voice_demo/tracing.py
@@ -11,6 +11,8 @@ sit next to each other in the LangSmith UI:
     voice-demo-livekit-with-gemini-live
     voice-demo-pipecat
     voice-demo-pipecat-with-langgraph
+    voice-demo-pipecat-with-openai-realtime
+    voice-demo-pipecat-with-gemini-live
 
 There are two tracing paths (see each backend's own module docstring for why):
 
@@ -40,6 +42,8 @@ Backend = Literal[
     "livekit-with-gemini-live",
     "pipecat",
     "pipecat-with-langgraph",
+    "pipecat-with-openai-realtime",
+    "pipecat-with-gemini-live",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -556,6 +556,22 @@ wheels = [
 ]
 
 [[package]]
+name = "deepgram-sdk"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/e1/d77f17f55fac94bf6aa81fb01a355ecfd923e12b5f19ef5a67cfc202d652/deepgram_sdk-7.4.0.tar.gz", hash = "sha256:0d35f830bcaa01196e3546b8c326f1d872f8fa52fc841c5640c2d68ef6678a03", size = 212507, upload-time = "2026-06-26T20:55:56.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/57/718090410686cbc8d039178e518ab9a010c9dd7bbef327918323f562274a/deepgram_sdk-7.4.0-py3-none-any.whl", hash = "sha256:713a84c22dfdb87fa37f44b36ece47938580e3343815254cc19fcaffff9915c5", size = 565593, upload-time = "2026-06-26T20:55:54.565Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -563,6 +579,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
 name = "docstring-parser"
@@ -1375,8 +1397,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.7"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../langsmith-sdk/python" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -1392,10 +1413,6 @@ dependencies = [
     { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/8b/a56b97a3b8a94f850fe2ec42351d4c508cc6bd7ca96644906c311e32ec5b/langsmith-0.9.7.tar.gz", hash = "sha256:40f8a66a466a7abd991a9df1b50de0a9d30c48ee0d3da46ce00516b68e41c9d7", size = 4711142, upload-time = "2026-07-02T20:11:09.619Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/95/0abb8647123c9ebbb31162bcdba3183f5f3d3bb2f752ef3d777ab715e88c/langsmith-0.9.7-py3-none-any.whl", hash = "sha256:a5ff9179b77eb0c3a0129294d30924eab13e51e2720f374372dbbc014c892911", size = 671052, upload-time = "2026-07-02T20:11:07.702Z" },
 ]
 
 [package.optional-dependencies]
@@ -1416,6 +1433,112 @@ pipecat = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pipecat-ai" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=3.5.0" },
+    { name = "cachetools", marker = "extra == 'livekit'", specifier = ">=5.0.0" },
+    { name = "cachetools", marker = "extra == 'pipecat'", specifier = ">=5.0.0" },
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10' and extra == 'claude-agent-sdk'", specifier = ">=0.1.0" },
+    { name = "distro", specifier = ">=1.7.0" },
+    { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
+    { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=1.14.0" },
+    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
+    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
+    { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
+    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
+    { name = "openai-agents", marker = "extra == 'openai-realtime'", specifier = ">=0.0.3" },
+    { name = "opentelemetry-api", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-api", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-api", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'", specifier = ">=3.9.14" },
+    { name = "packaging", specifier = ">=23.2" },
+    { name = "pipecat-ai", marker = "python_full_version >= '3.11' and extra == 'pipecat'", specifier = ">=1.0" },
+    { name = "pydantic", specifier = ">=2,<3" },
+    { name = "pytest", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
+    { name = "requests", specifier = ">=2.0.0" },
+    { name = "requests-toolbelt", specifier = ">=1.0.0" },
+    { name = "rich", marker = "extra == 'pytest'", specifier = ">=13.9.4" },
+    { name = "sniffio", specifier = ">=1.1" },
+    { name = "strands-agents", marker = "extra == 'strands-agents'", specifier = ">=0.1.0" },
+    { name = "strands-agents-tools", marker = "extra == 'strands-agents'", specifier = ">=0.2.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
+    { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
+    { name = "vcrpy", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
+    { name = "vcrpy", marker = "extra == 'vcr'", specifier = ">=7.0.0" },
+    { name = "websockets", specifier = ">=15.0" },
+    { name = "wrapt", marker = "extra == 'google-adk'", specifier = ">=1.16.0" },
+    { name = "xxhash", specifier = ">=3.0.0" },
+    { name = "zstandard", specifier = ">=0.23.0" },
+]
+provides-extras = ["claude-agent-sdk", "google-adk", "google-adk-live", "langsmith-pyo3", "livekit", "openai-agents", "openai-realtime", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bump2version", specifier = ">=1.0.1" },
+    { name = "cachetools", specifier = ">=5.0.0" },
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10'", specifier = ">=0.1.0" },
+    { name = "dataclasses-json", specifier = ">=0.6.4" },
+    { name = "debugpy", specifier = ">=1.8.17" },
+    { name = "fastapi", specifier = ">=0.115.4" },
+    { name = "freezegun", specifier = ">=1.2.2" },
+    { name = "google-adk", specifier = ">=1.0.0" },
+    { name = "google-genai", specifier = ">=1.2.0" },
+    { name = "httpx", specifier = ">=0.23.0,<0.29.0" },
+    { name = "langchain-anthropic", specifier = ">=1.0.0" },
+    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langchain-openai", specifier = ">=1.0.0" },
+    { name = "multipart", specifier = ">=1.0.0" },
+    { name = "mypy", specifier = ">=1.9.0" },
+    { name = "openai-agents", specifier = ">=0.2.4" },
+    { name = "opentelemetry-api", specifier = ">=1.34.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.34.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.34.1" },
+    { name = "pandas-stubs", specifier = ">=2.0.1.230501" },
+    { name = "pillow", specifier = ">=12.0.0" },
+    { name = "psutil", specifier = ">=5.9.5" },
+    { name = "py-spy", specifier = ">=0.3.14" },
+    { name = "pyperf", specifier = ">=2.7.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "pytest-httpx", specifier = ">=0.30.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14.0" },
+    { name = "pytest-retry", specifier = ">=1.7.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0" },
+    { name = "pytest-subtests", specifier = ">=0.11.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "pytest-watcher", specifier = ">=0.3.4" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "rich", specifier = ">=13.9.4" },
+    { name = "ruff", specifier = ">=0.6.9" },
+    { name = "strands-agents", specifier = ">=0.1.0" },
+    { name = "strands-agents-tools", specifier = ">=0.2.0" },
+    { name = "ty", specifier = "==0.0.44" },
+    { name = "types-psutil", specifier = ">=5.9.5.16" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.10" },
+    { name = "types-requests", specifier = ">=2.31.0.1" },
+    { name = "types-tqdm", specifier = ">=4.66.0.20240106" },
+    { name = "uvicorn", specifier = ">=0.29.0" },
+    { name = "vcrpy", specifier = ">=7.0.0" },
+    { name = "wrapt", specifier = ">=1.16.0" },
+]
+lint = [{ name = "openai", specifier = ">=2.6.0" }]
+test = [
+    { name = "anthropic", specifier = ">=0.45.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0" },
 ]
 
 [[package]]
@@ -1480,6 +1603,12 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+assemblyai = [
+    { name = "livekit-plugins-assemblyai" },
+]
+cartesia = [
+    { name = "livekit-plugins-cartesia" },
+]
 codecs = [
     { name = "numpy" },
 ]
@@ -1569,6 +1698,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/9a/7cdf1a77d5fd80e06533d4f2584c45d2c978f1249338969f814502db45ad/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80dc582413d816c86a0620410c2bfc3234e782a49d2b07b4bed0ff6285bdf4a1", size = 34824215, upload-time = "2026-06-24T16:55:45.02Z" },
     { url = "https://files.pythonhosted.org/packages/86/f2/0207071f236f639cf9515838ce98cfc3a8c1b19db8e6f46350e7231f2200/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c148ec2735e903dc00e37dc2580e0417f67ec7ee4be119dca7844b104afbfe9", size = 34868380, upload-time = "2026-06-24T16:55:48.119Z" },
     { url = "https://files.pythonhosted.org/packages/1e/91/c194db20c8e9272cadf0913d42392cda5eec5e78a14820a3fa678e42e4b6/livekit_local_inference-0.2.6-cp314-cp314-win_amd64.whl", hash = "sha256:4140e4fd60dd7b7d69a55e1d454d5d893f8ffe026c30e0d7cd31fa42b10d5621", size = 34914243, upload-time = "2026-06-24T16:55:51.322Z" },
+]
+
+[[package]]
+name = "livekit-plugins-assemblyai"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "livekit-agents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/78/361481fe2f1d8b3bf89ceaec75bbe485037a2410a82e2e96145a7a75ee6f/livekit_plugins_assemblyai-1.6.4.tar.gz", hash = "sha256:caad6c3805019e66e68873a881948b1cd99a46d4bc83a78c88f8d8111073dd4b", size = 12071, upload-time = "2026-06-24T20:49:23.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/60/dd172af5a6c4b153042da51f074eae8e99c662fabbb9e154bd69d634475e/livekit_plugins_assemblyai-1.6.4-py3-none-any.whl", hash = "sha256:127cb9efd3603198aae7d0b46d7031fc0681ea307308ab68a6dd0c067898a7a0", size = 12204, upload-time = "2026-06-24T20:49:22.487Z" },
+]
+
+[[package]]
+name = "livekit-plugins-cartesia"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "livekit-agents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/49/57110dd78a6397848c9e306abc5acc3af5dcd07c8377cb3efdf7a49f22a5/livekit_plugins_cartesia-1.6.4.tar.gz", hash = "sha256:17f502f58af7f5e835cc580b9644678d044c023e6d7abf2d4b314ccc53267619", size = 18195, upload-time = "2026-06-24T20:49:41.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/31/d99ea46858def84a0bcf2afe84fe8f06ed558ebf870cb638479f02b7ab6d/livekit_plugins_cartesia-1.6.4-py3-none-any.whl", hash = "sha256:4ef5887112299a5a43e6dc849190c5c4c3a854015f8c7d23b6c1919740e5dc8d", size = 25532, upload-time = "2026-06-24T20:49:40.632Z" },
 ]
 
 [[package]]
@@ -1961,6 +2114,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+]
+
+[[package]]
+name = "num2words"
+version = "0.5.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/58/ad645bd38b4b648eb2fc2ba1b909398e54eb0cbb6a7dbd2b4953e38c9621/num2words-0.5.14.tar.gz", hash = "sha256:b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6", size = 218213, upload-time = "2024-12-17T20:17:10.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/5b/545e9267a1cc080c8a1be2746113a063e34bcdd0f5173fd665a5c13cb234/num2words-0.5.14-py3-none-any.whl", hash = "sha256:1c8e5b00142fc2966fd8d685001e36c4a9911e070d1b120e1beb721fa1edb33d", size = 163525, upload-time = "2024-12-17T20:17:06.074Z" },
 ]
 
 [[package]]
@@ -2502,7 +2667,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-ai"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2512,6 +2677,7 @@ dependencies = [
     { name = "loguru" },
     { name = "markdown" },
     { name = "nltk" },
+    { name = "num2words" },
     { name = "numba" },
     { name = "numpy" },
     { name = "onnxruntime" },
@@ -2528,12 +2694,20 @@ dependencies = [
     { name = "wait-for2", marker = "python_full_version < '3.12'" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/ed/4bcf67703996ac6a0896dc64232e79fdfcb23eccff36929a7a234587a085/pipecat_ai-1.4.0.tar.gz", hash = "sha256:4d1e68da79e0632dcdaf66581fbf07e840249dfb715dc6e57b423d20fc3520d7", size = 11505429, upload-time = "2026-06-17T03:27:48.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/59/7b46ccbeb7c8f68083d0bc1ef39583e78938c6e65af1ff6f707051ea0948/pipecat_ai-1.5.0.tar.gz", hash = "sha256:df9bd5c3176076d425ffba3d510e0122d055b97c9ba8ad35a4390073eb421e18", size = 11624719, upload-time = "2026-07-04T17:11:50.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/ab/9acf81effd93f6f6d1ededbe5db8fedb50d196363d75188dc21d8aa71d5a/pipecat_ai-1.4.0-py3-none-any.whl", hash = "sha256:d7e1f2ee6f2646720daed3a028835d0e26e5e93787d0424ab00f4c7b6034a170", size = 11171447, upload-time = "2026-06-17T03:27:46.367Z" },
+    { url = "https://files.pythonhosted.org/packages/41/05/c7daebbf0fc59fd6106e34e52a255727443c1db49d046f7ed0bd9dcb6e4e/pipecat_ai-1.5.0-py3-none-any.whl", hash = "sha256:6089ac7ec418b310975c9c16dd472c16f99838810aae707d669b4f6f5981cf8a", size = 11264890, upload-time = "2026-07-04T17:11:47.677Z" },
 ]
 
 [package.optional-dependencies]
+deepgram = [
+    { name = "deepgram-sdk" },
+]
+google = [
+    { name = "google-cloud-speech" },
+    { name = "google-cloud-texttospeech" },
+    { name = "google-genai" },
+]
 local = [
     { name = "pyaudio" },
 ]
@@ -3893,7 +4067,7 @@ adk = [
 ]
 livekit = [
     { name = "langsmith", extra = ["livekit"] },
-    { name = "livekit-agents", extra = ["openai", "silero", "turn-detector"] },
+    { name = "livekit-agents", extra = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"] },
     { name = "livekit-plugins-google" },
 ]
 openai = [
@@ -3909,7 +4083,7 @@ pipecat = [
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "langsmith", extra = ["pipecat"] },
-    { name = "pipecat-ai", extra = ["local", "tracing"] },
+    { name = "pipecat-ai", extra = ["deepgram", "google", "local", "tracing"] },
 ]
 
 [package.metadata]
@@ -3921,11 +4095,11 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'pipecat'", specifier = ">=0.3" },
     { name = "langchain-openai", marker = "extra == 'pipecat'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'pipecat'", specifier = ">=0.2" },
-    { name = "langsmith", specifier = ">=0.9.7" },
-    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.9.7" },
-    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.9.7" },
-    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.9.7" },
-    { name = "livekit-agents", extras = ["openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
+    { name = "langsmith", editable = "../langsmith-sdk/python" },
+    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", editable = "../langsmith-sdk/python" },
+    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", editable = "../langsmith-sdk/python" },
+    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", editable = "../langsmith-sdk/python" },
+    { name = "livekit-agents", extras = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "livekit-plugins-google", marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.50" },
@@ -3933,7 +4107,7 @@ requires-dist = [
     { name = "openai-agents", extras = ["realtime"], marker = "extra == 'openai-agents'", specifier = ">=0.2" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", specifier = ">=1.27" },
-    { name = "pipecat-ai", extras = ["openai", "local", "tracing"], marker = "extra == 'pipecat'", specifier = ">=1.4" },
+    { name = "pipecat-ai", extras = ["deepgram", "google", "local", "openai", "tracing"], marker = "extra == 'pipecat'", specifier = ">=1.4" },
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "scipy", specifier = ">=1.13" },


### PR DESCRIPTION
## Summary

Two logical changes on this branch:

**Swap the cascade speech providers** (LLM stage stays OpenAI in both):
- **Pipecat** (`pipecat/`): STT + TTS now use **Deepgram** — `DeepgramSTTService` (Nova) and `DeepgramTTSService` (Aura). Requires `DEEPGRAM_API_KEY`.
- **LiveKit** (`livekit/`): STT now uses **AssemblyAI** and TTS uses **Cartesia** — `assemblyai.STT()` + `cartesia.TTS()`. Requires `ASSEMBLYAI_API_KEY` and `CARTESIA_API_KEY`.
  - ElevenLabs was evaluated first but its free tier returns HTTP 402 on all API calls, so Cartesia (usable free tier) was chosen instead.
- Each provider reads its key from the environment with a fail-fast startup check; no keys hardcoded or logged.
- `pyproject.toml` extras, `.env.example`, and the README backend table updated to match.

**Add the Pipecat speech-to-speech backends** (pre-existing work folded in): `pipecat_with_openai_realtime/` and `pipecat_with_gemini_live/`, plus the supporting `cli.py` / `tracing.py` wiring.

## Test plan

- [x] `uv sync --extra pipecat --extra livekit` resolves and installs cleanly
- [x] Deepgram STT/TTS instantiate via `api_key=` + `settings=…Settings(...)`
- [x] `assemblyai.STT()` and `cartesia.TTS()` expose and accept the `model`/`voice` kwargs used
- [x] Both agent modules import without error
- [x] AssemblyAI and Deepgram keys validated against their APIs; ElevenLabs 402 diagnosed as an account/billing gate (not a code bug)
- [x] No secret files or values staged; remote confirmed as `langchain-ai/voice-demo`
