### PR TITLE
chore(voice-demo): use PyPI langsmith release instead of local editable checkout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "sounddevice>=0.4",
     "numpy>=1.26",
     "scipy>=1.13",
-    "langsmith>=0.9.7",
+    "langsmith>=0.10.2",
     "httpx>=0.27",
     "pydantic>=2",
     "opentelemetry-sdk>=1.27",
@@ -27,12 +27,12 @@ openai-agents = [
 adk = [
     "google-adk>=2.0",
     "google-genai>=1.75",
-    "langsmith[google-adk]>=0.9.7",
+    "langsmith[google-adk]>=0.10.2",
 ]
 livekit = [
     # Covers all three LiveKit backends (cascade + the two S2S variants).
     # The LangSmith LiveKit integration (span processor + its deps, e.g. cachetools).
-    "langsmith[livekit]>=0.9.7",
+    "langsmith[livekit]>=0.10.2",
     # The agent is LiveKit-native (no LangChain brain): the cascade backend uses
     # assemblyai = STT and cartesia = TTS, openai = the LLM stage (and the
     # OpenAI Realtime model for the S2S variant); silero/turn-detector = VAD +
@@ -46,7 +46,7 @@ pipecat = [
     # Covers all four Pipecat backends: stock OpenAI LLM, the LangGraph variant,
     # OpenAI Realtime (S2S), and Gemini Live (S2S).
     # The LangSmith Pipecat integration (span processor + its deps, e.g. cachetools).
-    "langsmith[pipecat]>=0.9.7",
+    "langsmith[pipecat]>=0.10.2",
     # deepgram: STT + Aura TTS for the plain cascade backend · openai: the LLM
     # stage + OpenAI Realtime services · google: Gemini Live (pulls in
     # google-genai) · local: LocalAudioTransport (mic/speaker) · tracing: the
@@ -61,10 +61,6 @@ pipecat = [
     "langchain-openai>=0.2",
     "langchain-core>=0.3",
 ]
-
-[tool.uv.sources]
-# Use the local langsmith-sdk checkout (editable) instead of the PyPI release.
-langsmith = { path = "../langsmith-sdk/python", editable = true }
 
 [project.scripts]
 voice-demo = "voice_demo.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,8 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-source = { editable = "../langsmith-sdk/python" }
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -1413,6 +1414,10 @@ dependencies = [
     { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/8e/49a69c6793bf3fc5af62481e7e9b678fce59d1b384323d3ce87959a653e3/langsmith-0.10.2.tar.gz", hash = "sha256:9aa685383fbdec07a0df51dafc333ab0d4b6b995771172a232c3364714eb17a6", size = 4707343, upload-time = "2026-07-10T13:21:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/17/cc8eaf4e82e4bb22009bdde20085ff91719dce643d355fed94d523300130/langsmith-0.10.2-py3-none-any.whl", hash = "sha256:c2a3929055758ac1831582f0939fafc0973cc08432365bbad335c336338ec37c", size = 652545, upload-time = "2026-07-10T13:21:52.13Z" },
 ]
 
 [package.optional-dependencies]
@@ -1433,112 +1438,6 @@ pipecat = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pipecat-ai" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=3.5.0" },
-    { name = "cachetools", marker = "extra == 'livekit'", specifier = ">=5.0.0" },
-    { name = "cachetools", marker = "extra == 'pipecat'", specifier = ">=5.0.0" },
-    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10' and extra == 'claude-agent-sdk'", specifier = ">=0.1.0" },
-    { name = "distro", specifier = ">=1.7.0" },
-    { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
-    { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=1.14.0" },
-    { name = "httpx", specifier = ">=0.23.0,<1" },
-    { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
-    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
-    { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
-    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
-    { name = "openai-agents", marker = "extra == 'openai-realtime'", specifier = ">=0.0.3" },
-    { name = "opentelemetry-api", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-api", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-api", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'", specifier = ">=3.9.14" },
-    { name = "packaging", specifier = ">=23.2" },
-    { name = "pipecat-ai", marker = "python_full_version >= '3.11' and extra == 'pipecat'", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pytest", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
-    { name = "requests", specifier = ">=2.0.0" },
-    { name = "requests-toolbelt", specifier = ">=1.0.0" },
-    { name = "rich", marker = "extra == 'pytest'", specifier = ">=13.9.4" },
-    { name = "sniffio", specifier = ">=1.1" },
-    { name = "strands-agents", marker = "extra == 'strands-agents'", specifier = ">=0.1.0" },
-    { name = "strands-agents-tools", marker = "extra == 'strands-agents'", specifier = ">=0.2.0" },
-    { name = "typing-extensions", specifier = ">=4.0.0" },
-    { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
-    { name = "vcrpy", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
-    { name = "vcrpy", marker = "extra == 'vcr'", specifier = ">=7.0.0" },
-    { name = "websockets", specifier = ">=15.0" },
-    { name = "wrapt", marker = "extra == 'google-adk'", specifier = ">=1.16.0" },
-    { name = "xxhash", specifier = ">=3.0.0" },
-    { name = "zstandard", specifier = ">=0.23.0" },
-]
-provides-extras = ["claude-agent-sdk", "google-adk", "google-adk-live", "langsmith-pyo3", "livekit", "openai-agents", "openai-realtime", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "bump2version", specifier = ">=1.0.1" },
-    { name = "cachetools", specifier = ">=5.0.0" },
-    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10'", specifier = ">=0.1.0" },
-    { name = "dataclasses-json", specifier = ">=0.6.4" },
-    { name = "debugpy", specifier = ">=1.8.17" },
-    { name = "fastapi", specifier = ">=0.115.4" },
-    { name = "freezegun", specifier = ">=1.2.2" },
-    { name = "google-adk", specifier = ">=1.0.0" },
-    { name = "google-genai", specifier = ">=1.2.0" },
-    { name = "httpx", specifier = ">=0.23.0,<0.29.0" },
-    { name = "langchain-anthropic", specifier = ">=1.0.0" },
-    { name = "langchain-core", specifier = ">=1.0.0" },
-    { name = "langchain-openai", specifier = ">=1.0.0" },
-    { name = "multipart", specifier = ">=1.0.0" },
-    { name = "mypy", specifier = ">=1.9.0" },
-    { name = "openai-agents", specifier = ">=0.2.4" },
-    { name = "opentelemetry-api", specifier = ">=1.34.1" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.34.1" },
-    { name = "opentelemetry-sdk", specifier = ">=1.34.1" },
-    { name = "pandas-stubs", specifier = ">=2.0.1.230501" },
-    { name = "pillow", specifier = ">=12.0.0" },
-    { name = "psutil", specifier = ">=5.9.5" },
-    { name = "py-spy", specifier = ">=0.3.14" },
-    { name = "pyperf", specifier = ">=2.7.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "pytest-dotenv", specifier = ">=0.5.2" },
-    { name = "pytest-httpx", specifier = ">=0.30.0" },
-    { name = "pytest-rerunfailures", specifier = ">=14.0" },
-    { name = "pytest-retry", specifier = ">=1.7.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0" },
-    { name = "pytest-subtests", specifier = ">=0.11.0" },
-    { name = "pytest-timeout", specifier = ">=2.3.1" },
-    { name = "pytest-watcher", specifier = ">=0.3.4" },
-    { name = "pytest-xdist", specifier = ">=3.5.0" },
-    { name = "rich", specifier = ">=13.9.4" },
-    { name = "ruff", specifier = ">=0.6.9" },
-    { name = "strands-agents", specifier = ">=0.1.0" },
-    { name = "strands-agents-tools", specifier = ">=0.2.0" },
-    { name = "ty", specifier = "==0.0.44" },
-    { name = "types-psutil", specifier = ">=5.9.5.16" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.10" },
-    { name = "types-requests", specifier = ">=2.31.0.1" },
-    { name = "types-tqdm", specifier = ">=4.66.0.20240106" },
-    { name = "uvicorn", specifier = ">=0.29.0" },
-    { name = "vcrpy", specifier = ">=7.0.0" },
-    { name = "wrapt", specifier = ">=1.16.0" },
-]
-lint = [{ name = "openai", specifier = ">=2.6.0" }]
-test = [
-    { name = "anthropic", specifier = ">=0.45.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0" },
 ]
 
 [[package]]
@@ -4095,10 +3994,10 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'pipecat'", specifier = ">=0.3" },
     { name = "langchain-openai", marker = "extra == 'pipecat'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'pipecat'", specifier = ">=0.2" },
-    { name = "langsmith", editable = "../langsmith-sdk/python" },
-    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", editable = "../langsmith-sdk/python" },
-    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", editable = "../langsmith-sdk/python" },
-    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", editable = "../langsmith-sdk/python" },
+    { name = "langsmith", specifier = ">=0.10.2" },
+    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.2" },
+    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.2" },
+    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.2" },
     { name = "livekit-agents", extras = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "livekit-plugins-google", marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "numpy", specifier = ">=1.26" },


### PR DESCRIPTION
## Summary

Switch `langsmith` from the local editable checkout (`../langsmith-sdk/python`) to the published PyPI release.

- Remove the `[tool.uv.sources]` override that pinned `langsmith` to the local editable path
- Bump the `langsmith` specifiers (base dep + `google-adk`, `livekit`, `pipecat` extras) from `>=0.9.7` to `>=0.10.2` (latest PyPI release)
- Regenerate `uv.lock` — `langsmith` now resolves from `https://pypi.org/simple` at `0.10.2`

## Test plan

- [x] `uv lock` resolves cleanly with `langsmith` sourced from PyPI (no local path/editable entry in `uv.lock`)
