### PR TITLE
feat(livekit): capture realtime user transcript in openai + gemini demos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "sounddevice>=0.4",
     "numpy>=1.26",
     "scipy>=1.13",
-    "langsmith>=0.10.2",
+    "langsmith>=0.10.4",
     "httpx>=0.27",
     "pydantic>=2",
     "opentelemetry-sdk>=1.27",
@@ -27,12 +27,12 @@ openai-agents = [
 adk = [
     "google-adk>=2.3.0",
     "google-genai>=1.75",
-    "langsmith[google-adk]>=0.10.2",
+    "langsmith[google-adk]>=0.10.4",
 ]
 livekit = [
     # Covers all three LiveKit backends (cascade + the two S2S variants).
     # The LangSmith LiveKit integration (span processor + its deps, e.g. cachetools).
-    "langsmith[livekit]>=0.10.2",
+    "langsmith[livekit]>=0.10.4",
     # The agent is LiveKit-native (no LangChain brain): the cascade backend uses
     # assemblyai = STT and cartesia = TTS, openai = the LLM stage (and the
     # OpenAI Realtime model for the S2S variant); silero/turn-detector = VAD +
@@ -46,7 +46,7 @@ pipecat = [
     # Covers all four Pipecat backends: stock OpenAI LLM, the LangGraph variant,
     # OpenAI Realtime (S2S), and Gemini Live (S2S).
     # The LangSmith Pipecat integration (span processor + its deps, e.g. cachetools).
-    "langsmith[pipecat]>=0.10.2",
+    "langsmith[pipecat]>=0.10.4",
     # deepgram: STT + Aura TTS for the plain cascade backend · openai: the LLM
     # stage + OpenAI Realtime services · google: Gemini Live (pulls in
     # google-genai) · local: LocalAudioTransport (mic/speaker) · tracing: the

--- a/src/voice_demo/livekit_with_gemini_live/agent.py
+++ b/src/voice_demo/livekit_with_gemini_live/agent.py
@@ -59,8 +59,9 @@ def run(project_name: str) -> None:
     from ..weather import fetch_weather
 
     # --- Tracing wiring --- (see livekit/agent.py for the full rationale)
+    processor = None
     if os.environ.get("LANGSMITH_API_KEY"):
-        configure_livekit(
+        processor = configure_livekit(
             audio_path_provider=lambda: _audio_file_path,
             project=project_name,
         )
@@ -101,6 +102,8 @@ def run(project_name: str) -> None:
         _audio_file_path = ctx.session_directory / "audio.ogg"
 
         session = _build_session()
+        if processor is not None:
+            processor.instrument_session(session, ctx.job.id)
         await session.start(
             room=ctx.room,
             agent=_Assistant(),

--- a/src/voice_demo/livekit_with_openai_realtime/agent.py
+++ b/src/voice_demo/livekit_with_openai_realtime/agent.py
@@ -59,8 +59,9 @@ def run(project_name: str) -> None:
     from ..weather import fetch_weather
 
     # --- Tracing wiring --- (see livekit/agent.py for the full rationale)
+    processor = None
     if os.environ.get("LANGSMITH_API_KEY"):
-        configure_livekit(
+        processor = configure_livekit(
             audio_path_provider=lambda: _audio_file_path,
             project=project_name,
         )
@@ -103,6 +104,8 @@ def run(project_name: str) -> None:
         _audio_file_path = ctx.session_directory / "audio.ogg"
 
         session = _build_session()
+        if processor is not None:
+            processor.instrument_session(session, ctx.job.id)
         await session.start(
             room=ctx.room,
             agent=_Assistant(),

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.10.2"
+version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1415,9 +1415,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/8e/49a69c6793bf3fc5af62481e7e9b678fce59d1b384323d3ce87959a653e3/langsmith-0.10.2.tar.gz", hash = "sha256:9aa685383fbdec07a0df51dafc333ab0d4b6b995771172a232c3364714eb17a6", size = 4707343, upload-time = "2026-07-10T13:21:54.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/17/e8a73c6595fb58f12107a7c609034b32b24d7b2956e9dd079999344792be/langsmith-0.10.4.tar.gz", hash = "sha256:c13c750a044347b3b5eeb54572f1d85ed891d6055fc1c05397d1a3c0aa25a0ab", size = 4719993, upload-time = "2026-07-14T20:58:40.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/17/cc8eaf4e82e4bb22009bdde20085ff91719dce643d355fed94d523300130/langsmith-0.10.2-py3-none-any.whl", hash = "sha256:c2a3929055758ac1831582f0939fafc0973cc08432365bbad335c336338ec37c", size = 652545, upload-time = "2026-07-10T13:21:52.13Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/82/c6bae8dfea5ca79293a98293df0a8c84064a1850fc46ae69c49c6f97f14c/langsmith-0.10.4-py3-none-any.whl", hash = "sha256:73025846a1a4246e06b8bb513726aa88473b678163dbdf9c290273e431b07526", size = 657371, upload-time = "2026-07-14T20:58:38.174Z" },
 ]
 
 [package.optional-dependencies]
@@ -3994,10 +3994,10 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'pipecat'", specifier = ">=0.3" },
     { name = "langchain-openai", marker = "extra == 'pipecat'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'pipecat'", specifier = ">=0.2" },
-    { name = "langsmith", specifier = ">=0.10.2" },
-    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.2" },
-    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.2" },
-    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.2" },
+    { name = "langsmith", specifier = ">=0.10.4" },
+    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.4" },
+    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.4" },
+    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.4" },
     { name = "livekit-agents", extras = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "livekit-plugins-google", marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "numpy", specifier = ">=1.26" },


### PR DESCRIPTION
Update the livekit backends that use realtime models (gemini live or openai realtime) to use the new `instrument_session` helper to capture the user's transcript.

Also bumps the required `langsmith` floor to `>=0.10.4` (in the base dependency and the `google-adk`, `livekit`, and `pipecat` extras), which is the release where `instrument_session` was introduced.

#### PR Dependency Tree


* **PR #14** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)