### PR TITLE
feat(pipecat): capture realtime user transcript in openai + gemini demos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "sounddevice>=0.4",
     "numpy>=1.26",
     "scipy>=1.13",
-    "langsmith>=0.10.4",
+    "langsmith>=0.10.6",
     "httpx>=0.27",
     "pydantic>=2",
     "opentelemetry-sdk>=1.27",
@@ -27,12 +27,12 @@ openai-agents = [
 adk = [
     "google-adk>=2.3.0",
     "google-genai>=1.75",
-    "langsmith[google-adk]>=0.10.4",
+    "langsmith[google-adk]>=0.10.6",
 ]
 livekit = [
     # Covers all three LiveKit backends (cascade + the two S2S variants).
     # The LangSmith LiveKit integration (span processor + its deps, e.g. cachetools).
-    "langsmith[livekit]>=0.10.4",
+    "langsmith[livekit]>=0.10.6",
     # The agent is LiveKit-native (no LangChain brain): the cascade backend uses
     # assemblyai = STT and cartesia = TTS, openai = the LLM stage (and the
     # OpenAI Realtime model for the S2S variant); silero/turn-detector = VAD +
@@ -46,7 +46,7 @@ pipecat = [
     # Covers all four Pipecat backends: stock OpenAI LLM, the LangGraph variant,
     # OpenAI Realtime (S2S), and Gemini Live (S2S).
     # The LangSmith Pipecat integration (span processor + its deps, e.g. cachetools).
-    "langsmith[pipecat]>=0.10.4",
+    "langsmith[pipecat]>=0.10.6",
     # deepgram: STT + Aura TTS for the plain cascade backend · openai: the LLM
     # stage + OpenAI Realtime services · google: Gemini Live (pulls in
     # google-genai) · local: LocalAudioTransport (mic/speaker) · tracing: the

--- a/src/voice_demo/pipecat_with_gemini_live/agent.py
+++ b/src/voice_demo/pipecat_with_gemini_live/agent.py
@@ -211,6 +211,11 @@ async def run(project_name: str) -> None:
     audiobuffer = AudioBufferProcessor(num_channels=2, buffer_size=AUDIO_BUFFER_SIZE)
     if span_processor is not None:
         span_processor.attach_audio_buffer(audiobuffer, conversation_id)
+        # Gemini Live delivers the user's finalized text through the user context
+        # aggregator (on_user_turn_message_added), not an OTel span, so register
+        # it here — otherwise the user turns never reach the trace. This folds
+        # them onto the root and into each llm response's input history.
+        span_processor.instrument_user_aggregator(context_aggregator, conversation_id)
 
     # No stt/tts stages: the Gemini Live `llm` sits directly between the
     # transport's mic in and speaker out.

--- a/src/voice_demo/pipecat_with_openai_realtime/agent.py
+++ b/src/voice_demo/pipecat_with_openai_realtime/agent.py
@@ -90,7 +90,9 @@ async def run(project_name: str) -> None:
     from pipecat.services.llm_service import FunctionCallParams
     from pipecat.services.openai.realtime.events import (
         AudioConfiguration,
+        AudioInput,
         AudioOutput,
+        InputAudioTranscription,
         SessionProperties,
     )
     from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
@@ -147,7 +149,17 @@ async def run(project_name: str) -> None:
         settings=OpenAIRealtimeLLMService.Settings(
             model=REALTIME_MODEL,
             session_properties=SessionProperties(
-                audio=AudioConfiguration(output=AudioOutput(voice=REALTIME_VOICE)),
+                # Enable input-audio transcription: OpenAI Realtime sends the
+                # model raw audio and, by default, produces NO user-side text.
+                # Without this, the user's turns never appear in the context
+                # aggregator, so `on_user_turn_message_added` never fires and the
+                # trace shows only the assistant side. Turning it on makes OpenAI
+                # emit transcription events, which Pipecat surfaces to the
+                # aggregator and the LangSmith processor folds into the trace.
+                audio=AudioConfiguration(
+                    input=AudioInput(transcription=InputAudioTranscription()),
+                    output=AudioOutput(voice=REALTIME_VOICE),
+                ),
             ),
         ),
     )
@@ -201,6 +213,11 @@ async def run(project_name: str) -> None:
     audiobuffer = AudioBufferProcessor(num_channels=2, buffer_size=AUDIO_BUFFER_SIZE)
     if span_processor is not None:
         span_processor.attach_audio_buffer(audiobuffer, conversation_id)
+        # A realtime service delivers the user's finalized text through the user
+        # context aggregator (on_user_turn_message_added), not an OTel span, so
+        # register it here — otherwise the user turns never reach the trace. This
+        # folds them onto the root and into each llm response's input history.
+        span_processor.instrument_user_aggregator(context_aggregator, conversation_id)
 
     # No stt/tts stages: the realtime `llm` sits directly between the transport's
     # mic in and speaker out.

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.10.4"
+version = "0.10.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1415,9 +1415,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/17/e8a73c6595fb58f12107a7c609034b32b24d7b2956e9dd079999344792be/langsmith-0.10.4.tar.gz", hash = "sha256:c13c750a044347b3b5eeb54572f1d85ed891d6055fc1c05397d1a3c0aa25a0ab", size = 4719993, upload-time = "2026-07-14T20:58:40.508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/7e/05db6baaed1383386afd34e5d8fbf0b6cff1e87ed6b5c98d444511af6490/langsmith-0.10.6.tar.gz", hash = "sha256:6ec5b26bb57ee41363c07eb2884f24d69910b8d6bc26cae1f9e367af15259f1b", size = 4729044, upload-time = "2026-07-17T17:14:02.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/82/c6bae8dfea5ca79293a98293df0a8c84064a1850fc46ae69c49c6f97f14c/langsmith-0.10.4-py3-none-any.whl", hash = "sha256:73025846a1a4246e06b8bb513726aa88473b678163dbdf9c290273e431b07526", size = 657371, upload-time = "2026-07-14T20:58:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d5/2d8d84f5330aa773bae18644aaf7e3288b2f082e31640080784a7d908a24/langsmith-0.10.6-py3-none-any.whl", hash = "sha256:094285b755224f49fd396c3672b0f747294c7b8d9e8278a81d76b487b5cfdb56", size = 661257, upload-time = "2026-07-17T17:14:01.118Z" },
 ]
 
 [package.optional-dependencies]
@@ -3994,10 +3994,10 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'pipecat'", specifier = ">=0.3" },
     { name = "langchain-openai", marker = "extra == 'pipecat'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'pipecat'", specifier = ">=0.2" },
-    { name = "langsmith", specifier = ">=0.10.4" },
-    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.4" },
-    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.4" },
-    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.4" },
+    { name = "langsmith", specifier = ">=0.10.6" },
+    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.6" },
+    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.6" },
+    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.6" },
     { name = "livekit-agents", extras = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "livekit-plugins-google", marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "numpy", specifier = ">=1.26" },


### PR DESCRIPTION
## Summary

A realtime (speech-to-speech) service delivers the user's finalized text through the user context aggregator (`on_user_turn_message_added`), not an OTel span. Without wiring it up, the trace only ever shows the assistant side — the user's turns never reach LangSmith.

This mirrors what #14 did for the LiveKit S2S backends, but for the two Pipecat S2S backends (OpenAI Realtime + Gemini Live).

## Changes

- **Both pipecat S2S backends** (`pipecat_with_openai_realtime`, `pipecat_with_gemini_live`): register the user context aggregator with the LangSmith span processor via `span_processor.instrument_user_aggregator(context_aggregator, conversation_id)` so user turns are folded onto the root run and into each LLM response's input history.
- **OpenAI Realtime only**: enable input-audio transcription with `AudioConfiguration(input=AudioInput(transcription=InputAudioTranscription()))`. OpenAI Realtime sends the model raw audio and by default produces **no** user-side text, so without this the context aggregator never fires. (Gemini Live already surfaces user text through the aggregator, so it needs no extra config.)
- **`pyproject.toml` / `uv.lock`**: drop the local `[tool.uv.sources]` editable overrides for `langsmith-sdk` and `pipecat-ai` and re-resolve against PyPI (`langsmith` 0.10.6, `pipecat-ai` 1.5.0). Both new APIs (`instrument_user_aggregator`, `AudioInput` / `InputAudioTranscription`) are available in the published releases.

## Verification

Confirmed `instrument_user_aggregator` ships in published `langsmith==0.10.6` and `AudioInput` / `InputAudioTranscription` ship in published `pipecat-ai==1.5.0`, so this PR no longer depends on the local editable checkouts.
