### PR TITLE
feat: add raw Gemini Live voice demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ DEEPGRAM_API_KEY=
 ASSEMBLYAI_API_KEY=
 CARTESIA_API_KEY=
 
-# Used by: the Google ADK Live backend and the livekit-with-gemini-live variant.
+# Used by: raw Gemini Live, Google ADK Live, and the Gemini Live framework variants.
 GOOGLE_API_KEY=
 
 # LiveKit — console mode doesn't need a real server, but the SDK still

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repo implements a variety of voice agent backends across different framewor
 |---|---|
 | `openai` | OpenAI Realtime, raw WebSocket |
 | `openai-agents` | OpenAI Realtime, via the Agents SDK |
+| `gemini` | Gemini Live, raw WebSocket via the official `google-genai` SDK |
 | `adk` | Google ADK Live (Gemini) |
 | `livekit` | LiveKit STT → LLM → TTS cascade (AssemblyAI STT · OpenAI LLM · Cartesia TTS) |
 | `livekit-with-langgraph` | LiveKit, but the Agent's `llm_node` runs an in-process LangGraph agent — LiveKit owns the ChatContext (barge-in-truncated transcript), LangGraph owns the control flow |
@@ -29,7 +30,7 @@ purpose, so each one reads as one complete example).
 Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-uv sync --all-extras     # or one backend's deps: --extra openai / openai-agents / adk / livekit / pipecat
+uv sync --all-extras     # or one backend's deps: --extra openai / openai-agents / gemini / adk / livekit / pipecat
 cp .env.example .env      # then fill in the keys below
 ```
 
@@ -43,6 +44,7 @@ Fill in `.env` with your own API keys.
 ```bash
 uv run voice-demo --backend openai
 uv run voice-demo --backend openai-agents
+uv run voice-demo --backend gemini
 uv run voice-demo --backend adk
 uv run voice-demo --backend livekit
 uv run voice-demo --backend livekit-with-langgraph
@@ -63,7 +65,7 @@ Things to try:
 - Interrupt the agent while it's talking — watch it stop and listen.
 
 Traces land in a LangSmith project per backend: `voice-demo-openai`,
-`voice-demo-adk`, `voice-demo-livekit`, and so on. Override the name with
+`voice-demo-gemini`, `voice-demo-adk`, `voice-demo-livekit`, and so on. Override the name with
 `--project`, or pass `--debug` for verbose tracing logs.
 
 ## How the tracing works
@@ -83,11 +85,11 @@ src/voice_demo/
 ├── prompts.py     # shared system prompt + greeting
 ├── weather.py     # shared Open-Meteo lookup (no API key)
 │
-├── openai/, openai_agents/, adk/           # event-stream backends (each has an agent.py)
+├── openai/, openai_agents/, gemini/, adk/  # event-stream backends (each has an agent.py)
 └── livekit*/, pipecat*/                     # in-process backends (each has an agent.py)
 ```
 
-The OpenAI and ADK backends ship no console of their own, so `cli.py` builds one
+The OpenAI, Gemini, and ADK backends ship no console of their own, so `cli.py` builds one
 and injects it through small protocols (`AudioInput` / `AudioOutput` /
 `StatusUI`). To drive the same agent from a web app or a phone call, implement
 those interfaces and inject your own — without touching the agent's event loop,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "sounddevice>=0.4",
     "numpy>=1.26",
     "scipy>=1.13",
-    "langsmith>=0.10.6",
+    "langsmith>=0.10.14",
     "httpx>=0.27",
     "pydantic>=2",
     "opentelemetry-sdk>=1.27",
@@ -31,12 +31,12 @@ gemini = [
 adk = [
     "google-adk>=2.3.0",
     "google-genai>=1.75",
-    "langsmith[google-adk]>=0.10.6",
+    "langsmith[google-adk]>=0.10.14",
 ]
 livekit = [
     # Covers all three LiveKit backends (cascade + the two S2S variants).
     # The LangSmith LiveKit integration (span processor + its deps, e.g. cachetools).
-    "langsmith[livekit]>=0.10.6",
+    "langsmith[livekit]>=0.10.14",
     # The agent is LiveKit-native (no LangChain brain): the cascade backend uses
     # assemblyai = STT and cartesia = TTS, openai = the LLM stage (and the
     # OpenAI Realtime model for the S2S variant); silero/turn-detector = VAD +
@@ -57,7 +57,7 @@ pipecat = [
     # Covers all four Pipecat backends: stock OpenAI LLM, the LangGraph variant,
     # OpenAI Realtime (S2S), and Gemini Live (S2S).
     # The LangSmith Pipecat integration (span processor + its deps, e.g. cachetools).
-    "langsmith[pipecat]>=0.10.6",
+    "langsmith[pipecat]>=0.10.14",
     # deepgram: STT + Aura TTS for the plain cascade backend · openai: the LLM
     # stage + OpenAI Realtime services · google: Gemini Live (pulls in
     # google-genai) · local: LocalAudioTransport (mic/speaker) · tracing: the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "voice-demo"
 version = "0.1.0"
-description = "Voice-agent backends (OpenAI Realtime, Google ADK Live, LiveKit STT/LLM/TTS cascade, LiveKit speech-to-speech with OpenAI Realtime / Gemini Live, Pipecat, Pipecat with a LangGraph brain, and Pipecat speech-to-speech with OpenAI Realtime / Gemini Live), each instrumented for LangSmith the way its framework intends."
+description = "Voice-agent backends (raw OpenAI Realtime, raw Gemini Live, Google ADK Live, LiveKit and Pipecat cascades, and framework speech-to-speech variants), each instrumented for LangSmith the way its framework intends."
 requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.0",
@@ -23,6 +23,10 @@ openai-agents = [
     # Same Realtime model as the `openai` extra, driven through the Agents SDK.
     "openai-agents[realtime]>=0.2",
     "openai>=1.50",
+]
+gemini = [
+    # Gemini Live over google-genai's official raw WebSocket session.
+    "google-genai>=1.75",
 ]
 adk = [
     "google-adk>=2.3.0",

--- a/src/voice_demo/__init__.py
+++ b/src/voice_demo/__init__.py
@@ -1,9 +1,9 @@
 """voice-demo: several voice-agent backends sharing one console interface.
 
 Run `voice-demo --backend <name>` to launch a console session against the chosen
-backend: openai, openai-agents, adk, livekit, livekit-with-openai-realtime,
+backend: openai, openai-agents, gemini, adk, livekit, livekit-with-openai-realtime,
 livekit-with-gemini-live, pipecat, or pipecat-with-langgraph. Each backend is
 traced to LangSmith using the optimal path for its framework (OTEL for LiveKit,
-Pipecat, and ADK; SDK RunTree for OpenAI Realtime). See README.md for the
+Pipecat, and ADK; SDK RunTree for OpenAI Realtime and raw Gemini Live). See README.md for the
 rationale.
 """

--- a/src/voice_demo/cli.py
+++ b/src/voice_demo/cli.py
@@ -1,6 +1,6 @@
 """Entry point: `voice-demo --backend <name>`.
 
-Backends: openai · openai-agents · adk · livekit · livekit-with-openai-realtime ·
+Backends: openai · openai-agents · gemini · adk · livekit · livekit-with-openai-realtime ·
 livekit-with-gemini-live · pipecat · pipecat-with-langgraph ·
 pipecat-with-openai-realtime · pipecat-with-gemini-live. The
 `*-with-openai-realtime` / `*-with-gemini-live` / `livekit-with-*` backends swap
@@ -43,8 +43,8 @@ for _candidate in (_HERE / ".env", _HERE.parent.parent / ".env"):
         load_dotenv(_candidate, override=False)
         break
 
-# Both SDK backends run the local mic + speaker at 24 kHz (ADK resamples to
-# 16 kHz internally before sending to Gemini).
+# All direct SDK backends run the local mic + speaker at 24 kHz (Gemini and ADK
+# resample to 16 kHz internally before sending audio to Gemini Live).
 _CONSOLE_SAMPLE_RATE = 24_000
 
 
@@ -73,6 +73,7 @@ def main() -> None:
         choices=(
             "openai",
             "openai-agents",
+            "gemini",
             "adk",
             "livekit",
             "livekit-with-langgraph",
@@ -116,6 +117,12 @@ def main() -> None:
         from .openai_agents.agent import run as run_openai_agents
 
         _run_console_backend(run_openai_agents, project)
+
+    elif args.backend == "gemini":
+        # Gemini Live over google-genai's raw WebSocket session, without ADK.
+        from .gemini.agent import run as run_gemini
+
+        _run_console_backend(run_gemini, project)
 
     elif args.backend == "adk":
         from .adk.agent import run as run_adk

--- a/src/voice_demo/gemini/__init__.py
+++ b/src/voice_demo/gemini/__init__.py
@@ -1,0 +1,6 @@
+"""Gemini Live voice agent over the raw ``google-genai`` WebSocket session.
+
+This is the framework-free Gemini twin of :mod:`voice_demo.openai`: the app
+owns the provider event loop, audio playback, barge-in handling, and tool
+dispatch, while LangSmith's ``wrap_gemini_live`` integration owns tracing.
+"""

--- a/src/voice_demo/gemini/agent.py
+++ b/src/voice_demo/gemini/agent.py
@@ -23,7 +23,7 @@ from langsmith.integrations.gemini_live import wrap_gemini_live
 
 from ..audio import AudioInput, AudioOutput, resample_pcm16
 from ..console import NullUI, StatusUI, frame_level
-from .events import LiveMessage
+from .events import LiveMessage, append_transcript
 from .tools import execute_tool
 
 SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
@@ -145,6 +145,8 @@ async def run(
             async def pump_responses() -> None:
                 # Gemini's receive() generator ends at each turn_complete, so
                 # open a new generator for every subsequent user turn.
+                user_transcript = ""
+                agent_transcript = ""
                 while True:
                     async for raw_message in session.receive():
                         message = LiveMessage(raw_message)
@@ -157,12 +159,35 @@ async def run(
                             audio_out.write(chunk)
                             ui.set_state("speaking")
 
-                        if message.user_transcript:
+                        if user_fragment := message.user_transcript:
+                            user_transcript = append_transcript(
+                                user_transcript, user_fragment
+                            )
                             ui.set_state("hearing you")
-                        if message.final_user_transcript:
-                            ui.log(f"user:  {message.final_user_transcript}")
-                        if message.final_agent_transcript:
-                            ui.log(f"agent: {message.final_agent_transcript}")
+                        if message.user_transcript_finished:
+                            if user_transcript:
+                                ui.log(f"user:  {user_transcript}")
+                            user_transcript = ""
+
+                        if agent_fragment := message.agent_transcript:
+                            agent_transcript = append_transcript(
+                                agent_transcript, agent_fragment
+                            )
+                        if message.agent_transcript_finished:
+                            if agent_transcript:
+                                ui.log(f"agent: {agent_transcript}")
+                            agent_transcript = ""
+
+                        # Gemini can omit a transcription-finished signal. ADK
+                        # flushes its fragment accumulators at these same live
+                        # boundaries so text never leaks into the next turn.
+                        if message.interrupted or message.turn_complete:
+                            if user_transcript:
+                                ui.log(f"user:  {user_transcript}")
+                                user_transcript = ""
+                            if agent_transcript:
+                                ui.log(f"agent: {agent_transcript}")
+                                agent_transcript = ""
 
                         if message.function_calls:
                             ui.set_state("running tools")

--- a/src/voice_demo/gemini/agent.py
+++ b/src/voice_demo/gemini/agent.py
@@ -1,0 +1,215 @@
+"""Gemini Live voice agent over the official SDK's raw WebSocket session.
+
+This backend is parallel to ``voice_demo.openai``: it uses no agent framework.
+The application directly drives ``client.aio.live.connect(...)``, streams PCM
+microphone frames, consumes provider messages, plays audio, handles barge-in,
+and dispatches tools. ``langsmith.integrations.gemini_live.wrap_gemini_live``
+wraps the session at the event-stream boundary and owns all trace decisions.
+
+The agent is frontend-agnostic. Its local console, mic, and speaker are injected
+through ``AudioInput`` / ``AudioOutput`` / ``StatusUI`` protocols.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+
+from google import genai
+from google.genai import types
+from langsmith.integrations.gemini_live import wrap_gemini_live
+
+from ..audio import AudioInput, AudioOutput, resample_pcm16
+from ..console import NullUI, StatusUI, frame_level
+from .events import LiveMessage
+from .tools import execute_tool
+
+SYSTEM_PROMPT = """You are a friendly voice assistant who can look up the
+weather for any city. Keep replies short, conversational, and free of
+formatting (no asterisks, no bullet points, no emoji). When the user asks
+about weather in one or more places, call the lookup_weather tool once per
+city, then summarize the results naturally in one or two short sentences."""
+
+DEFAULT_MODEL = os.getenv("GEMINI_LIVE_MODEL", "gemini-3.1-flash-live-preview")
+SEND_SAMPLE_RATE = 16_000
+RECV_SAMPLE_RATE = 24_000
+
+WEATHER_TOOL = types.Tool(
+    function_declarations=[
+        types.FunctionDeclaration(
+            name="lookup_weather",
+            description=(
+                "Get the current weather for a single city. Call once per city "
+                "for multi-city questions."
+            ),
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "City name, such as San Francisco or Tokyo.",
+                    }
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        )
+    ]
+)
+
+
+def _live_config() -> types.LiveConnectConfig:
+    return types.LiveConnectConfig(
+        response_modalities=[types.Modality.AUDIO],
+        system_instruction=SYSTEM_PROMPT,
+        tools=[WEATHER_TOOL],
+        input_audio_transcription=types.AudioTranscriptionConfig(),
+        output_audio_transcription=types.AudioTranscriptionConfig(),
+        speech_config=types.SpeechConfig(
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name="Aoede")
+            )
+        ),
+        realtime_input_config=types.RealtimeInputConfig(
+            automatic_activity_detection=types.AutomaticActivityDetection(
+                start_of_speech_sensitivity=types.StartSensitivity.START_SENSITIVITY_HIGH,
+                end_of_speech_sensitivity=types.EndSensitivity.END_SENSITIVITY_LOW,
+                prefix_padding_ms=200,
+                silence_duration_ms=800,
+            )
+        ),
+    )
+
+
+async def run(
+    project_name: str,
+    *,
+    audio_in: AudioInput,
+    audio_out: AudioOutput,
+    ui: StatusUI | None = None,
+) -> None:
+    """Drive a raw Gemini Live conversation over the supplied audio frontend."""
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print("GOOGLE_API_KEY is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    ui = ui or NullUI()
+    thread_id = str(uuid.uuid4())
+    client = genai.Client(api_key=api_key)
+
+    ui.log(f"[gemini] thread_id={thread_id}")
+    ui.log(f"[gemini] connecting to Gemini Live with model={DEFAULT_MODEL}...")
+
+    mic_task: asyncio.Task | None = None
+    receive_task: asyncio.Task | None = None
+    try:
+        async with (
+            client.aio.live.connect(model=DEFAULT_MODEL, config=_live_config()) as raw,
+            wrap_gemini_live(
+                raw,
+                model=DEFAULT_MODEL,
+                thread_id=thread_id,
+                sample_rate=RECV_SAMPLE_RATE,
+                project_name=project_name,
+                tags=["voice-demo", "gemini"],
+                metadata={"model": DEFAULT_MODEL},
+                is_agent_speaking=lambda: audio_out.buffered_bytes() > 0,
+            ) as session,
+        ):
+            # Capture what the listener actually heard. Audio removed by
+            # ``clear()`` during barge-in never reaches this callback.
+            audio_out.set_played_callback(session.record_agent_audio)
+            audio_in.start()
+            audio_out.start()
+            ui.log("[gemini] connected. Talk into your mic — Ctrl-C to quit.")
+            ui.set_state("listening")
+
+            async def pump_mic() -> None:
+                async for frame in audio_in.frames():
+                    await session.send_realtime_input(
+                        audio=types.Blob(
+                            data=resample_pcm16(
+                                frame, audio_in.sample_rate, SEND_SAMPLE_RATE
+                            ),
+                            mime_type=f"audio/pcm;rate={SEND_SAMPLE_RATE}",
+                        )
+                    )
+                    session.record_user_audio(
+                        resample_pcm16(frame, audio_in.sample_rate, RECV_SAMPLE_RATE)
+                    )
+                    ui.update_level(frame_level(frame))
+
+            async def pump_responses() -> None:
+                # Gemini's receive() generator ends at each turn_complete, so
+                # open a new generator for every subsequent user turn.
+                while True:
+                    async for raw_message in session.receive():
+                        message = LiveMessage(raw_message)
+
+                        if message.interrupted:
+                            audio_out.clear()
+                            ui.set_state("hearing you")
+
+                        for chunk in message.audio_chunks:
+                            audio_out.write(chunk)
+                            ui.set_state("speaking")
+
+                        if message.user_transcript:
+                            ui.set_state("hearing you")
+                        if message.final_user_transcript:
+                            ui.log(f"user:  {message.final_user_transcript}")
+                        if message.final_agent_transcript:
+                            ui.log(f"agent: {message.final_agent_transcript}")
+
+                        if message.function_calls:
+                            ui.set_state("running tools")
+                            responses: list[types.FunctionResponse] = []
+                            for call in message.function_calls:
+                                if not getattr(call, "id", None):
+                                    ui.log(
+                                        "[gemini] ignored malformed tool call without an id"
+                                    )
+                                    continue
+                                result = await execute_tool(
+                                    getattr(call, "name", None),
+                                    getattr(call, "args", None),
+                                )
+                                responses.append(
+                                    types.FunctionResponse(
+                                        id=call.id,
+                                        name=call.name,
+                                        response=result,
+                                    )
+                                )
+                            if responses:
+                                ui.set_state("thinking")
+                                await session.send_tool_response(
+                                    function_responses=responses
+                                )
+
+                        if message.turn_complete:
+                            ui.set_state("listening")
+
+            mic_task = asyncio.create_task(pump_mic())
+            receive_task = asyncio.create_task(pump_responses())
+            await asyncio.gather(mic_task, receive_task)
+
+    except asyncio.CancelledError:
+        pass
+    except Exception as exc:
+        ui.log(f"[gemini] error: {exc}")
+    finally:
+        for task in (mic_task, receive_task):
+            if task is not None:
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (mic_task, receive_task) if task is not None),
+            return_exceptions=True,
+        )
+        audio_out.set_played_callback(None)
+        audio_in.stop()
+        audio_out.stop()
+        ui.finish()

--- a/src/voice_demo/gemini/events.py
+++ b/src/voice_demo/gemini/events.py
@@ -1,0 +1,64 @@
+"""Readable view over raw ``google.genai`` Gemini Live server messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class LiveMessage:
+    """Expose the application-relevant fields of a ``LiveServerMessage``."""
+
+    def __init__(self, raw: Any) -> None:
+        self.raw = raw
+
+    @property
+    def server_content(self) -> Any:
+        return getattr(self.raw, "server_content", None)
+
+    @property
+    def interrupted(self) -> bool:
+        content = self.server_content
+        return bool(content is not None and getattr(content, "interrupted", False))
+
+    @property
+    def turn_complete(self) -> bool:
+        content = self.server_content
+        return bool(content is not None and getattr(content, "turn_complete", False))
+
+    def _transcript(self, attr: str, *, final_only: bool) -> str | None:
+        content = self.server_content
+        tx = getattr(content, attr, None) if content is not None else None
+        text = getattr(tx, "text", None) if tx is not None else None
+        if not text or (final_only and not getattr(tx, "finished", False)):
+            return None
+        return str(text)
+
+    @property
+    def user_transcript(self) -> str | None:
+        return self._transcript("input_transcription", final_only=False)
+
+    @property
+    def final_user_transcript(self) -> str | None:
+        return self._transcript("input_transcription", final_only=True)
+
+    @property
+    def final_agent_transcript(self) -> str | None:
+        return self._transcript("output_transcription", final_only=True)
+
+    @property
+    def audio_chunks(self) -> list[bytes]:
+        content = self.server_content
+        turn = getattr(content, "model_turn", None) if content is not None else None
+        parts = getattr(turn, "parts", None) if turn is not None else None
+        chunks: list[bytes] = []
+        for part in parts or []:
+            blob = getattr(part, "inline_data", None)
+            data = getattr(blob, "data", None) if blob is not None else None
+            if isinstance(data, bytes) and data:
+                chunks.append(data)
+        return chunks
+
+    @property
+    def function_calls(self) -> list[Any]:
+        tool_call = getattr(self.raw, "tool_call", None)
+        return list(getattr(tool_call, "function_calls", None) or [])

--- a/src/voice_demo/gemini/events.py
+++ b/src/voice_demo/gemini/events.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
+MAX_TRANSCRIPT_CHARS = 2_000
+
+
+def append_transcript(current: str, fragment: str) -> str:
+    """Append one Gemini transcription delta, retaining the per-turn cap."""
+    remaining = MAX_TRANSCRIPT_CHARS - len(current)
+    return current if remaining <= 0 else current + fragment[:remaining]
+
 
 class LiveMessage:
     """Expose the application-relevant fields of a ``LiveServerMessage``."""
@@ -25,25 +33,34 @@ class LiveMessage:
         content = self.server_content
         return bool(content is not None and getattr(content, "turn_complete", False))
 
-    def _transcript(self, attr: str, *, final_only: bool) -> str | None:
+    def _transcription(self, attr: str) -> Any:
         content = self.server_content
-        tx = getattr(content, attr, None) if content is not None else None
+        return getattr(content, attr, None) if content is not None else None
+
+    def _transcript(self, attr: str) -> str | None:
+        tx = self._transcription(attr)
         text = getattr(tx, "text", None) if tx is not None else None
-        if not text or (final_only and not getattr(tx, "finished", False)):
-            return None
-        return str(text)
+        return str(text) if text else None
+
+    def _transcript_finished(self, attr: str) -> bool:
+        tx = self._transcription(attr)
+        return bool(tx is not None and getattr(tx, "finished", False))
 
     @property
     def user_transcript(self) -> str | None:
-        return self._transcript("input_transcription", final_only=False)
+        return self._transcript("input_transcription")
 
     @property
-    def final_user_transcript(self) -> str | None:
-        return self._transcript("input_transcription", final_only=True)
+    def user_transcript_finished(self) -> bool:
+        return self._transcript_finished("input_transcription")
 
     @property
-    def final_agent_transcript(self) -> str | None:
-        return self._transcript("output_transcription", final_only=True)
+    def agent_transcript(self) -> str | None:
+        return self._transcript("output_transcription")
+
+    @property
+    def agent_transcript_finished(self) -> bool:
+        return self._transcript_finished("output_transcription")
 
     @property
     def audio_chunks(self) -> list[bytes]:

--- a/src/voice_demo/gemini/tools.py
+++ b/src/voice_demo/gemini/tools.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from langsmith import traceable
-
 from ..weather import fetch_weather
 
 
-@traceable(run_type="tool", name="lookup_weather")
 async def lookup_weather(city: str) -> dict:
     """Get the current weather for one city from the shared Open-Meteo client."""
     return await fetch_weather(city)

--- a/src/voice_demo/gemini/tools.py
+++ b/src/voice_demo/gemini/tools.py
@@ -1,0 +1,27 @@
+"""Allowlisted application tool dispatch for the raw Gemini Live backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langsmith import traceable
+
+from ..weather import fetch_weather
+
+
+@traceable(run_type="tool", name="lookup_weather")
+async def lookup_weather(city: str) -> dict:
+    """Get the current weather for one city from the shared Open-Meteo client."""
+    return await fetch_weather(city)
+
+
+async def execute_tool(name: str | None, arguments: Any) -> dict:
+    """Execute one known tool; malformed or unknown calls return safe errors."""
+    if name != "lookup_weather":
+        return {"error": f"unknown tool: {name or '<missing>'}"}
+    if not isinstance(arguments, dict):
+        return {"error": "tool arguments must be an object"}
+    city = arguments.get("city")
+    if not isinstance(city, str) or not city.strip():
+        return {"error": "missing city"}
+    return await lookup_weather(city.strip())

--- a/src/voice_demo/tracing.py
+++ b/src/voice_demo/tracing.py
@@ -5,6 +5,7 @@ sit next to each other in the LangSmith UI:
 
     voice-demo-openai
     voice-demo-openai-agents
+    voice-demo-gemini
     voice-demo-adk
     voice-demo-livekit
     voice-demo-livekit-with-langgraph
@@ -21,8 +22,8 @@ There are two tracing paths (see each backend's own module docstring for why):
     framework in-process that emits its own OTel spans; the LangSmith
     integrations translate and export those (`langsmith.integrations.{livekit,
     pipecat}`).
-  * SDK  — OpenAI Realtime and ADK Live consume a remote event stream and build
-    the trace themselves with the LangSmith SDK (`RunTree`).
+  * SDK  — OpenAI Realtime, raw Gemini Live, and ADK Live consume a remote event
+    stream and build the trace themselves with the LangSmith SDK (`RunTree`).
 
 Either way the integrations read LangSmith config (API key, project, endpoint)
 from the standard `LANGSMITH_*` environment, so this module only sets those.
@@ -37,6 +38,7 @@ from typing import Literal
 Backend = Literal[
     "openai",
     "openai-agents",
+    "gemini",
     "adk",
     "livekit",
     "livekit-with-langgraph",

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.10.6"
+version = "0.10.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1415,9 +1415,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/7e/05db6baaed1383386afd34e5d8fbf0b6cff1e87ed6b5c98d444511af6490/langsmith-0.10.6.tar.gz", hash = "sha256:6ec5b26bb57ee41363c07eb2884f24d69910b8d6bc26cae1f9e367af15259f1b", size = 4729044, upload-time = "2026-07-17T17:14:02.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/c2/804558586a5363af85fc5b03ea327d0ba5d4d83da4c7d53fbed2413ef681/langsmith-0.10.14.tar.gz", hash = "sha256:edd3711ed1a334e5fb87b15eb0777b5abe5ad931dc13bfb79b93fffcbd2c2b4c", size = 4782076, upload-time = "2026-07-30T23:27:22.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/d5/2d8d84f5330aa773bae18644aaf7e3288b2f082e31640080784a7d908a24/langsmith-0.10.6-py3-none-any.whl", hash = "sha256:094285b755224f49fd396c3672b0f747294c7b8d9e8278a81d76b487b5cfdb56", size = 661257, upload-time = "2026-07-17T17:14:01.118Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/178c8c5bb50efd3e88986212993349aa027ff90364ccd4db4e3c596aede6/langsmith-0.10.14-py3-none-any.whl", hash = "sha256:185432f170c1639e9be14aad4116ba59079753a5762c7e1a26c11cf9988f8288", size = 726292, upload-time = "2026-07-30T23:27:20.333Z" },
 ]
 
 [package.optional-dependencies]
@@ -4006,10 +4006,10 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'pipecat'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'livekit'", specifier = ">=0.2" },
     { name = "langgraph", marker = "extra == 'pipecat'", specifier = ">=0.2" },
-    { name = "langsmith", specifier = ">=0.10.6" },
-    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.6" },
-    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.6" },
-    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.6" },
+    { name = "langsmith", specifier = ">=0.10.14" },
+    { name = "langsmith", extras = ["google-adk"], marker = "extra == 'adk'", specifier = ">=0.10.14" },
+    { name = "langsmith", extras = ["livekit"], marker = "extra == 'livekit'", specifier = ">=0.10.14" },
+    { name = "langsmith", extras = ["pipecat"], marker = "extra == 'pipecat'", specifier = ">=0.10.14" },
     { name = "livekit-agents", extras = ["assemblyai", "cartesia", "openai", "silero", "turn-detector"], marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "livekit-plugins-google", marker = "extra == 'livekit'", specifier = ">=1.6.4" },
     { name = "numpy", specifier = ">=1.26" },

--- a/uv.lock
+++ b/uv.lock
@@ -3964,6 +3964,9 @@ adk = [
     { name = "google-genai" },
     { name = "langsmith", extra = ["google-adk"] },
 ]
+gemini = [
+    { name = "google-genai" },
+]
 livekit = [
     { name = "langchain" },
     { name = "langchain-core" },
@@ -3993,6 +3996,7 @@ pipecat = [
 requires-dist = [
     { name = "google-adk", marker = "extra == 'adk'", specifier = ">=2.3.0" },
     { name = "google-genai", marker = "extra == 'adk'", specifier = ">=1.75" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.75" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "langchain", marker = "extra == 'livekit'", specifier = ">=1.3.9" },
     { name = "langchain", marker = "extra == 'pipecat'", specifier = ">=1.3.9" },
@@ -4020,7 +4024,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13" },
     { name = "sounddevice", specifier = ">=0.4" },
 ]
-provides-extras = ["openai", "openai-agents", "adk", "livekit", "pipecat"]
+provides-extras = ["openai", "openai-agents", "gemini", "adk", "livekit", "pipecat"]
 
 [[package]]
 name = "wait-for2"


### PR DESCRIPTION
## Summary

- add a raw Gemini Live voice agent using the official `google-genai` WebSocket session
- add `--backend gemini` configuration and a `gemini` uv extra
- trace the session with the new LangSmith Gemini Live integration
- keep the published LangSmith SDK dependency rather than a local editable source

## Dependency

Depends on https://github.com/langchain-ai/langsmith-sdk/pull/3291 and a LangSmith SDK release containing that integration.

## Testing

- `uv lock --check`
- Ruff formatting and lint checks
- import and configuration smoke test against the local SDK implementation


#### PR Dependency Tree


* **PR #17** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)